### PR TITLE
[audit] replace deprecated vim.treesitter.get_node_range with node:range()

### DIFF
--- a/lua/config/scopeline.lua
+++ b/lua/config/scopeline.lua
@@ -19,7 +19,7 @@ function draw_scope_lines()
     local ts_node = vim.treesitter.get_node({ pos = { cursor[1], cursor[2] } })
     while ts_node do
         if valid_scopes[ts_node:type()] then
-            local start_row, start_col, end_row, end_col = vim.treesitter.get_node_range(ts_node)
+            local start_row, start_col, end_row, end_col = ts_node:range()
             for i = start_row + 1, end_row - 1 do
                 local char = char_at(i + 1, start_col + 1) -- treesitter is 0 based
                 if char == " " then


### PR DESCRIPTION
## What

Replace the deprecated `vim.treesitter.get_node_range(node)` wrapper with the direct method call `node:range()`.

## Where

`lua/config/scopeline.lua:22`

```lua
-- before
local start_row, start_col, end_row, end_col = vim.treesitter.get_node_range(ts_node)

-- after
local start_row, start_col, end_row, end_col = ts_node:range()
```

## Why it matters

`vim.treesitter.get_node_range()` was deprecated in Neovim 0.10 (see `:help news-0.10` — *"vim.treesitter.get_node_range() is deprecated, use TSNode:range() instead"*). The method form `node:range()` has been available since Neovim 0.8 and is the canonical API going forward.

## Recommended action

Merge as-is — identical return values, no behaviour change.

---
_Generated by [Claude Code](https://claude.ai/code/session_019yqiXEkjm726tY68164bKJ)_