### PR TITLE
[audit] add missing filetypes to sourcekit-lsp config

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -70,6 +70,7 @@ if not is_vscode then
     -- swift
     vim.lsp.config["sourcekit"] = {
         cmd = { "sourcekit-lsp" },
+        filetypes = { "swift", "objective-c", "objective-cpp" },
         root_markers = { "Package.swift", "compilation_commands.json", ".git" },
     }
     vim.lsp.enable("sourcekit")
@@ -135,4 +136,3 @@ if fff_ok then
         )
     end
 end
-


### PR DESCRIPTION
## What

Adds a `filetypes` field to the `sourcekit` LSP config in `lua/config/plugin_config.lua:71-75`.

**Before:**
```lua
vim.lsp.config["sourcekit"] = {
    cmd = { "sourcekit-lsp" },
    root_markers = { "Package.swift", "compilation_commands.json", ".git" },
}
```

**After:**
```lua
vim.lsp.config["sourcekit"] = {
    cmd = { "sourcekit-lsp" },
    filetypes = { "swift", "objective-c", "objective-cpp" },
    root_markers = { "Package.swift", "compilation_commands.json", ".git" },
}
```

## Where

`lua/config/plugin_config.lua:71-75`

## Why it matters

Without a `filetypes` field, Neovim has no way to know which buffers `sourcekit-lsp` should attach to. The server is enabled via `vim.lsp.enable("sourcekit")` but will never start because the filetype trigger is missing. Swift files open silently without LSP.

The three filetypes (`swift`, `objective-c`, `objective-cpp`) match the defaults in nvim-lspconfig's own sourcekit entry and cover the languages sourcekit-lsp handles.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnYXZ9vT8P2yUR5wfBc4B7)_