### PR TITLE
[audit] Use local fzf ref for actions; make current_git_branch local

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -8,7 +8,7 @@ if ok and not is_vscode then
             rg_opts = [[--color=never --hidden --files -g "!.git" -g "!.jj"]],
             hidden = true,
             actions = {
-                ["ctrl-alt-h"] = FzfLua.actions.toggle_hidden,
+                ["ctrl-alt-h"] = fzf.actions.toggle_hidden,
             },
         },
         grep = {
@@ -23,7 +23,7 @@ if ok and not is_vscode then
             }, " "),
             hidden = true,
             actions = {
-                ["ctrl-alt-h"] = FzfLua.actions.toggle_hidden,
+                ["ctrl-alt-h"] = fzf.actions.toggle_hidden,
             },
         },
     })

--- a/lua/config/statusline.lua
+++ b/lua/config/statusline.lua
@@ -22,12 +22,12 @@ vim.api.nvim_create_autocmd("ColorScheme", {
 })
 
 -- git sign
-function current_git_branch()
+local function current_git_branch()
     local ok, gs = pcall(require, "gitsigns")
     if not ok then return "" end
     local branch = vim.b.gitsigns_head
     if not branch or branch == "" then return "" end
-    return " %#Git#  " .. branch .. " " .. "%*"
+    return " %#Git#  " .. branch .. " " .. "%*"
 end
 
 -- cursor


### PR DESCRIPTION
## What

Two small mechanical cleanups found during config audit.

### 1. `plugin_config.lua` — replace `FzfLua` global with local `fzf` ref

**Where:** `lua/config/plugin_config.lua:11,26`

The `ctrl-alt-h` toggle action was referencing the implicit global `FzfLua` that fzf-lua sets as a side-effect of being required:

```lua
-- before
["ctrl-alt-h"] = FzfLua.actions.toggle_hidden,

-- after
["ctrl-alt-h"] = fzf.actions.toggle_hidden,
```

The local `fzf` variable (from `pcall(require, "fzf-lua")` on line 4) is the same object. Using it directly is consistent with the rest of the block, removes the dependency on fzf-lua's `_G.FzfLua` side-effect, and makes the intent obvious.

### 2. `statusline.lua` — make `current_git_branch` a local function

**Where:** `lua/config/statusline.lua:25`

`current_git_branch()` was declared without `local`, making it a global. It is only ever called from `StatusLine()` in the same file. Adding `local` avoids polluting `_G` with an implementation-detail name.

(`StatusLine` itself must remain global because it is referenced by `vim.opt.statusline = "%!v:lua.StatusLine()"` — that is intentional and unchanged.)

## Testing

- Open a file, confirm `ctrl-alt-h` still toggles hidden files in fzf-lua pickers.
- Reload config, confirm statusline still renders correctly.
- Confirm `current_git_branch` is no longer accessible as a global (`:lua print(current_git_branch)` should print `nil`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gtz7LPQRyHUGQVBgJvMf39)_