### PR TITLE
[audit] fix DiagnosticSignError hijacked as statusline highlight

### DIFF
--- a/lua/config/statusline.lua
+++ b/lua/config/statusline.lua
@@ -18,7 +18,7 @@ vim.api.nvim_create_autocmd("ColorScheme", {
         vim.api.nvim_set_hl(0, "FileAlt", { fg = "#3A3A3A" })
         vim.api.nvim_set_hl(0, "FileType", { fg = "black", bg = "#3E8FB0" })
         vim.api.nvim_set_hl(0, "FileTypeAlt", { fg = "#3E8FB0" })
-        vim.api.nvim_set_hl(0, "DiagnosticSignError", { bg = "#7E85A5", fg = "black" })
+        vim.api.nvim_set_hl(0, "StatusLineDiag", { bg = "#7E85A5", fg = "black" })
         vim.cmd("redrawstatus")
     end,
 })
@@ -176,7 +176,7 @@ local function current_diagnostics()
         end
     end
     return " "
-        .. "%#DiagnosticSignError#"
+        .. "%#StatusLineDiag#"
         .. SOLID_LEFT_ARROW
         .. "  "
         .. _n_ERROR


### PR DESCRIPTION
## What

Rename the `DiagnosticSignError` highlight group usage in the statusline to a dedicated `StatusLineDiag` group.

## Where

`lua/config/statusline.lua:18` (highlight definition) and `:179` (`%#DiagnosticSignError#` format string in `current_diagnostics()`).

## Why it matters

`DiagnosticSignError` is a standard Neovim highlight group that colours the **sign column** error glyph. Redefining it with a grey background (`#7E85A5`) and black foreground overrides that everywhere — making sign-column error indicators appear as grey boxes instead of the colourscheme's intended red/bold style.

## Changes

- `statusline.lua:18`: define `StatusLineDiag` instead of overriding `DiagnosticSignError`
- `statusline.lua:179`: reference `%#StatusLineDiag#` in the format string

Closes #25

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc622cZqwmegvwTJxSfynY)_