### PR TITLE
[audit] fix sourcekit-lsp root_markers typo: compilation_commands → compile_commands

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -71,7 +71,7 @@ if not is_vscode then
     vim.lsp.config["sourcekit"] = {
         cmd = { "sourcekit-lsp" },
         filetypes = { "swift", "objective-c", "objective-cpp" },
-        root_markers = { "Package.swift", "compilation_commands.json", ".git" },
+        root_markers = { "Package.swift", "compile_commands.json", ".git" },
     }
     vim.lsp.enable("sourcekit")
 end


### PR DESCRIPTION
## What

`lua/config/plugin_config.lua:73` has a typo in the sourcekit-lsp `root_markers`:

```lua
-- before
root_markers = { "Package.swift", "compilation_commands.json", ".git" },

-- after
root_markers = { "Package.swift", "compile_commands.json", ".git" },
```

## Where

`lua/config/plugin_config.lua:73`

## Why it matters

The correct filename for a [Clang compilation database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) is `compile_commands.json`. The misspelled `compilation_commands.json` will never match an actual file on disk, so sourcekit-lsp silently falls back to `.git` as the only root marker. In projects that rely on the compilation database for correct include resolution (e.g. mixed Swift/C++ projects, or standalone C++ with Xcode tooling), LSP features like go-to-definition and diagnostics will work with degraded accuracy.

## Change

One-character fix — rename `compilation_commands.json` → `compile_commands.json`. No behaviour change for pure Swift projects; improves root detection for projects that generate a compilation database.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9ERHRjSrNBqR96MkUFPrM)_