### PR TITLE
[audit] replace io.popen with vim.fn.system in get_glibc_version

### DIFF
--- a/lua/config/treesitter.lua
+++ b/lua/config/treesitter.lua
@@ -4,13 +4,10 @@
 
 -- this function needs to be updated occasionally, as of 260130, glibc should be at least 2.30
 local function get_glibc_version()
-    local handle = io.popen("ldd --version 2>&1 | head -n1")
-    if not handle then
+    local result = vim.fn.system("ldd --version 2>&1 | head -n1")
+    if vim.v.shell_error ~= 0 then
         return nil
     end
-    local result = handle:read("*a")
-    handle:close()
-
     local version = result:match("(%d+%.%d+)%s*$") or result:match("GLIBC (%d+%.%d+)")
     if version then
         return tonumber(version)


### PR DESCRIPTION
## What

`lua/config/treesitter.lua:6-18` uses `io.popen` (Lua stdlib) to run `ldd --version` and parse the glibc version:

```lua
local handle = io.popen("ldd --version 2>&1 | head -n1")
if not handle then return nil end
local result = handle:read("*a")
handle:close()
```

Replaced with `vim.fn.system` (Neovim-idiomatic):

```lua
local result = vim.fn.system("ldd --version 2>&1 | head -n1")
if vim.v.shell_error ~= 0 then return nil end
```

## Why it matters

- `io.popen` is a raw Lua stdlib call that bypasses Neovim's job infrastructure. `vim.fn.system` goes through Neovim's shell layer, respects `shellcmdflag`/`shell` options, and sets `vim.v.shell_error` for proper error detection.
- The old code silently returned garbage output on `ldd` failure (non-zero exit) because `io.popen` doesn't surface exit codes — the handle read would succeed but return error text. The new code checks `vim.v.shell_error` and returns `nil` cleanly.
- Removes the `handle:close()` boilerplate and the `if not handle` nil-guard (unnecessary with `vim.fn.system`).

## Risk

Low — pure drop-in replacement, identical semantics for the happy path. The function is only called at startup to decide whether to auto-install tree-sitter parsers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xzq5bFewuta6qFJJQ4csf6)_