### PR TITLE
[audit] fix inverted guard in build_latest_parsers (TSSync latest was always a no-op)

### DIFF
--- a/lua/config/treesitter.lua
+++ b/lua/config/treesitter.lua
@@ -89,7 +89,7 @@ ts_install()
 -- this pulls and builds latest parsers since nvim-treesitter is no longer updated
 -- TODO: query files might be incompatible overtime (I dont know how to write those for now but worth checking later)
 local function build_latest_parsers(parser_dir)
-    if can_auto_install_parsers() then
+    if not can_auto_install_parsers() then
         return
     end
     local cache_dir = vim.fn.stdpath("cache") .. "/treesitter-parsers-latest"


### PR DESCRIPTION
## What

`lua/config/treesitter.lua:92` has an inverted guard that makes `TSSync latest` silently do nothing.

```lua
-- before (broken)
local function build_latest_parsers(parser_dir)
    if can_auto_install_parsers() then   -- ← exits when tools ARE available
        return
    end
```

```lua
-- after (fixed)
local function build_latest_parsers(parser_dir)
    if not can_auto_install_parsers() then  -- ← exits when tools are NOT available
        return
    end
```

## Where

`lua/config/treesitter.lua:92`

## Why it matters

`build_latest_parsers` is called from `ts_update` only when `can_auto_install_parsers()` is already `true` (both glibc ≥ 2.30 and `tree-sitter-cli` present). With the old guard the function immediately returned in exactly that condition, so `:TSSync latest` would reinstall the bundled nvim-treesitter parsers via `ts_install()` but then silently skip the "pull and build latest from upstream" step — the entire point of passing `latest`.

The fix is a single `not`: exit early only when the required tools are *absent*, which is the only case where building is impossible.

## Testing

Run `:TSSync latest` with `tree-sitter-cli` installed — the function should now proceed to clone upstream parser repos and compile `.so` files instead of returning immediately.


---
_Generated by [Claude Code](https://claude.ai/code/session_011GYnQTwWqwnYzHqGv3HgZP)_