### PR TITLE
[audit] Downgrade vim._core.ui2 startup notifications from WARN to DEBUG

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -146,9 +146,9 @@ if not vim.g.vscode then
     local ok, ui2 = pcall(require, "vim._core.ui2")
     if ok then
         pcall(ui2.enable)
-        vim.notify("ui2 enabled", vim.log.levels.WARN)
+        vim.notify("ui2 enabled", vim.log.levels.DEBUG)
     else
-        vim.notify("ui2 disabled (could be old nvim or api shift, check options.lua)", vim.log.levels.WARN)
+        vim.notify("ui2 disabled (could be old nvim or api shift, check options.lua)", vim.log.levels.DEBUG)
     end
 end
 


### PR DESCRIPTION
## What

`lua/config/options.lua:147,149` — two `vim.notify(..., vim.log.levels.WARN)` calls inside the experimental `vim._core.ui2` probe block.

## Where

`lua/config/options.lua:146-153`

```lua
local ok, ui2 = pcall(require, "vim._core.ui2")
if ok then
    pcall(ui2.enable)
    vim.notify("ui2 enabled", vim.log.levels.WARN)   -- ← fires every start on nightly
else
    vim.notify("ui2 disabled ...", vim.log.levels.WARN) -- ← fires every start on stable
end
```

## Why it matters

- `vim._core` is a private namespace — this is an experimental probe, not an actionable condition.
- The "disabled" branch fires on **every stable Neovim startup** (the common case), flooding the notification history with a WARN that the user cannot do anything about.
- WARN-level messages appear in status-bar alert UIs (e.g. noice.nvim, fidget) and in `:messages`, creating ongoing noise.

## Change

Both calls are downgraded to `vim.log.levels.DEBUG`. Debug messages are suppressed by default and only appear when actively debugging — the probe still runs, `ui2` still enables if available, but the user isn't spammed on every launch.

## Risk

Low. Purely cosmetic/log-level change; no functional behaviour altered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWDuy9gK4ijDJRDNfAitCz)_