### PR TITLE
[audit] Downgrade ui2 experiment startup notifications from WARN to DEBUG

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -146,9 +146,9 @@ if not vim.g.vscode then
     local ok, ui2 = pcall(require, "vim._core.ui2")
     if ok then
         pcall(ui2.enable)
-        vim.notify("ui2 enabled", vim.log.levels.WARN)
+        vim.notify("ui2 enabled", vim.log.levels.DEBUG)
     else
-        vim.notify("ui2 disabled (could be old nvim or api shift, check options.lua)", vim.log.levels.WARN)
+        vim.notify("ui2 disabled (could be old nvim or api shift, check options.lua)", vim.log.levels.DEBUG)
     end
 end
 


### PR DESCRIPTION
## What

`lua/config/options.lua:148-151` emits two `vim.log.levels.WARN` notifications on **every startup** — one if the private `vim._core.ui2` module loads, one if it doesn't. WARN is the level that surfaces in the message area and `:messages` history, so users see this flash on every launch regardless of intent.

## Where

`lua/config/options.lua:148-151`

```lua
-- before
vim.notify("ui2 enabled", vim.log.levels.WARN)
-- ...
vim.notify("ui2 disabled (could be old nvim or api shift, check options.lua)", vim.log.levels.WARN)
```

## Why it matters

`vim._core.ui2` is explicitly an experiment (prefixed `_core`, wrapped in `pcall`). The WARN level is semantically wrong — WARN implies something unexpected or broken. Here, both branches are normal expected outcomes. Downgrading to DEBUG keeps the diagnostic reachable via `:messages` or a debug logger without polluting the startup message area.

## Change

Both `vim.log.levels.WARN` → `vim.log.levels.DEBUG`.

## Notes

- `vim._core.ui2` is a private, undocumented Neovim API. The `pcall` guard is correct; this PR only fixes the log level.
- No behaviour change — ui2 is still enabled when available.

https://claude.ai/code/session_01XkBn411UWSYV978A5e76rD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkBn411UWSYV978A5e76rD)_