### PR TITLE
[audit] Move gd/gr LSP keymaps to LspAttach

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -37,10 +37,8 @@ vim.keymap.set("n", "<leader>cc", "<cmd>cclose<CR>", { desc = "[C]lose quickfix 
 vim.keymap.set("i", "<c-space>", "<c-x><c-o>", { desc = "LSP completion" })
 vim.keymap.set("i", "<c-l>", "<c-x><c-l>", { desc = "Line completion" })
 vim.keymap.set("i", "<c-f>", "<c-x><c-f>", { desc = "File completion" })
--- lsp
+-- lsp keymaps: gd / gr set buffer-local in plugin_config.lua via LspAttach
 -- todo: it is a bit annoying to have repeated entries when multiple lsps exist, should either dedup or show sources
-vim.keymap.set("n", "gd", vim.lsp.buf.definition)
-vim.keymap.set("n", "gr", vim.lsp.buf.references)
 
 -- diagnostics: tag source so multiple LSPs are distinguishable
 vim.diagnostic.config({

--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -76,6 +76,13 @@ if not is_vscode then
         root_markers = { "Package.swift", "compile_commands.json", ".git" },
     }
     vim.lsp.enable("sourcekit")
+    vim.api.nvim_create_autocmd("LspAttach", {
+        callback = function(ev)
+            local opts = { buffer = ev.buf }
+            vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
+            vim.keymap.set("n", "gr", vim.lsp.buf.references, opts)
+        end,
+    })
 end
 
 -- conform (formatting)


### PR DESCRIPTION
## What

Move `gd` and `gr` from global keymaps in `options.lua` into a `LspAttach` autocmd in `plugin_config.lua`, making them buffer-local and only active when an LSP client actually attaches.

## Where

- `lua/config/options.lua:42-43` — removed global `gd`/`gr` bindings
- `lua/config/plugin_config.lua` — added `LspAttach` autocmd (inside the `if not is_vscode then` block)

## Why

As global keymaps they fired in every buffer — terminal, quickfix, help, plain text — overriding Neovim's built-in `gd` ("go to local declaration") in non-LSP buffers, and producing "no client attached" errors from `gr` in those same buffers. `LspAttach` (available since Neovim 0.11) is the idiomatic pattern for exactly this reason.

Closes #27.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpQ2eCorW2b6yFMXHTXBrh)_