### PR TITLE
[audit] Add vim.lsp.config for pyrefly LSP

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -60,6 +60,11 @@ if not is_vscode then
     vim.lsp.enable("pyright")
     -- install via uv: uv tool install pyrefly, then pyrefly init inside project folder (will transfer configs from pyright if available)
     -- pyrefly seems capable of showing more type issues as far as I can tell
+    vim.lsp.config["pyrefly"] = {
+        cmd = { "pyrefly", "lsp" },
+        filetypes = { "python" },
+        root_markers = { "pyrefly.toml", "pyproject.toml", ".git" },
+    }
     vim.lsp.enable("pyrefly")
     -- install using system package manager
     vim.lsp.enable("clangd")


### PR DESCRIPTION
## What

Add an explicit `vim.lsp.config["pyrefly"]` block before the existing `vim.lsp.enable("pyrefly")` call.

## Where

`lua/config/plugin_config.lua:63` — between the pyright enable and the pyrefly enable.

## Why

`vim.lsp.enable()` looks up config from three sources in order: user-defined `vim.lsp.config`, nvim-lspconfig bundled defaults, Neovim built-ins. Pyrefly is not in any of those for the pinned nvim-lspconfig commit, so the call was silently a no-op — the server never started.

The config entry uses `cmd = { "pyrefly", "lsp" }` (pyrefly's LSP subcommand) with `root_markers` that match what `pyrefly init` generates (`pyrefly.toml`) plus the pyright fallbacks.

**Note:** pyright and pyrefly both attach to Python files simultaneously, which is intentional per the inline comment. Expect doubled diagnostics until one is disabled per-project.

Closes #56.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpQ2eCorW2b6yFMXHTXBrh)_