### PR TITLE
[audit] Replace vim.treesitter.highlighter.active with local state

### DIFF
--- a/lua/config/treesitter.lua
+++ b/lua/config/treesitter.lua
@@ -144,7 +144,7 @@ local function ts_highlight()
         ts_highlight_active[bufnr] = true
     end
 end
-vim.api.nvim_create_autocmd("BufDelete", {
+vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
     callback = function(ev) ts_highlight_active[ev.buf] = nil end,
 })
 

--- a/lua/config/treesitter.lua
+++ b/lua/config/treesitter.lua
@@ -133,17 +133,21 @@ local function build_latest_parsers(parser_dir)
         :wait()
 end
 
-local function is_ts_enabled()
-    local bufnr = vim.api.nvim_get_current_buf()
-    return vim.treesitter.highlighter.active[bufnr] ~= nil
-end
+local ts_highlight_active = {}
 local function ts_highlight()
-    if is_ts_enabled() then
-        vim.treesitter.stop()
+    local bufnr = vim.api.nvim_get_current_buf()
+    if ts_highlight_active[bufnr] then
+        vim.treesitter.stop(bufnr)
+        ts_highlight_active[bufnr] = false
     else
-        vim.treesitter.start()
+        vim.treesitter.start(bufnr)
+        ts_highlight_active[bufnr] = true
     end
 end
+vim.api.nvim_create_autocmd("BufDelete", {
+    callback = function(ev) ts_highlight_active[ev.buf] = nil end,
+})
+
 -- sometimes ts dont update all parsers and it fails things, you need to remove both parser and queries folder
 local function ts_update(opts)
     if ts_status and can_auto_install_parsers() then
@@ -165,9 +169,12 @@ vim.api.nvim_create_user_command("TSSync", ts_update, { nargs = "?" })
 vim.api.nvim_create_autocmd("FileType", {
     pattern = { "*" },
     callback = function()
-        local ok, err = pcall(vim.treesitter.start)
+        local bufnr = vim.api.nvim_get_current_buf()
+        local ok = pcall(vim.treesitter.start)
         if not ok then
             vim.cmd("syntax on")
+        else
+            ts_highlight_active[bufnr] = true
         end
     end,
 })


### PR DESCRIPTION
## What

Replace the `is_ts_enabled()` function (which reads the internal `vim.treesitter.highlighter.active` table) with a module-local `ts_highlight_active` table that tracks toggle state explicitly.

## Where

`lua/config/treesitter.lua:136-146` — `is_ts_enabled` + `ts_highlight`, used by `TSBufToggle`.

## Why

`vim.treesitter.highlighter` is an internal Lua class; `.active` is a private field not part of the public API and not documented in `:help treesitter`. It has silently changed before and could again in any nightly or stable release.

## Changes

- `is_ts_enabled()` removed; toggle state lives in `ts_highlight_active[bufnr]`
- `ts_highlight()` calls `vim.treesitter.stop(bufnr)` / `vim.treesitter.start(bufnr)` with explicit bufnr
- New `BufDelete` autocmd cleans up the table to prevent accumulation
- `FileType` autocmd sets `ts_highlight_active[bufnr] = true` when `vim.treesitter.start()` succeeds, so initial state is correct before any toggle

Closes #60.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpQ2eCorW2b6yFMXHTXBrh)_