### PR TITLE
[audit] call gitsigns.setup() — statusline git branch was always empty

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -140,6 +140,12 @@ if fff_ok then
     end
 end
 
+-- gitsigns
+local gitsigns_ok, gitsigns = pcall(require, "gitsigns")
+if gitsigns_ok and not is_vscode then
+    gitsigns.setup()
+end
+
 -- treesitter textobjects (move keymaps for function/class navigation)
 local tso_ok, tso = pcall(require, "nvim-treesitter-textobjects")
 if tso_ok and not is_vscode then


### PR DESCRIPTION
## What

Add `gitsigns.setup()` call in `lua/config/plugin_config.lua`.

## Where

`lua/config/plugin_config.lua` — new block inserted between the conform setup and the treesitter-textobjects block.

## Why it matters

`statusline.lua` reads `vim.b.gitsigns_head` to show the current git branch:

```lua
local branch = vim.b.gitsigns_head
```

That buffer variable is only written by gitsigns **after it attaches to a buffer**, which only happens once `gitsigns.setup()` has been called. Because `plugin_config.lua` never called `setup()`, gitsigns was installed but never activated — the branch segment in the statusline was silently always empty.

## Fix

```lua
local gitsigns_ok, gitsigns = pcall(require, "gitsigns")
if gitsigns_ok and not is_vscode then
    gitsigns.setup()
end
```

Uses the same `pcall` + `is_vscode` guard pattern as every other plugin in this file. No config arguments needed — gitsigns defaults are fine and all customisation (keymaps, blame, etc.) can be added later per issue #14.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3j2qAAux9R2FXzD1ZrVdb)_