### PR TITLE
[follow-up] fix fff keymap gating to avoid runtime errors when fff.nvim is unavailable

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -114,36 +114,35 @@ if conform_ok and not is_vscode then
 end
 
 -- fff
-local fff_ok, _ = pcall(function()
-    vim.api.nvim_create_autocmd("PackChanged", {
-        callback = function(ev)
-            local name, kind = ev.data.spec.name, ev.data.kind
-            if name == "fff.nvim" and (kind == "install" or kind == "update") then
-                if not ev.data.active then
-                    vim.cmd.packadd("fff.nvim")
-                end
-                require("fff.download").download_or_build_binary()
+vim.api.nvim_create_autocmd("PackChanged", {
+    callback = function(ev)
+        local name, kind = ev.data.spec.name, ev.data.kind
+        if name == "fff.nvim" and (kind == "install" or kind == "update") then
+            if not ev.data.active then
+                vim.cmd.packadd("fff.nvim")
             end
-        end,
-    })
-end)
-if fff_ok then
-    vim.g.fff = {
-        lazy_sync = true,
-        debug = {
-            enabled = true,
-            show_scores = true,
-        },
-    }
-    if not is_vscode then
-        vim.keymap.set("n", "ff", function()
-            require("fff").find_files()
-        end, { desc = "fff files" })
-        -- you can toggle between grep, fuzzy grep, regex grep with shift+tab after launching fff grep
-        vim.keymap.set("n", "fg", function()
-            require("fff").live_grep()
-        end, { desc = "fff grep" })
-    end
+            require("fff.download").download_or_build_binary()
+        end
+    end,
+})
+
+vim.g.fff = {
+    lazy_sync = true,
+    debug = {
+        enabled = true,
+        show_scores = true,
+    },
+}
+
+local fff_ok = pcall(require, "fff")
+if fff_ok and not is_vscode then
+    vim.keymap.set("n", "ff", function()
+        require("fff").find_files()
+    end, { desc = "fff files" })
+    -- you can toggle between grep, fuzzy grep, regex grep with shift+tab after launching fff grep
+    vim.keymap.set("n", "fg", function()
+        require("fff").live_grep()
+    end, { desc = "fff grep" })
 end
 
 -- gitsigns


### PR DESCRIPTION
### Motivation
- The previous guard used a `pcall` around `vim.api.nvim_create_autocmd` which always succeeds, so `fff_ok` was always true and the `ff`/`fg` keymaps were registered even when `fff.nvim` could not be required. This produced runtime errors on fresh or old-package-path installs. 
- The intent is to only register keymaps when the `fff` module is actually loadable while still keeping the `PackChanged` autocmd behavior and `vim.g.fff` settings.

### Description
- Always register the `PackChanged` autocmd directly to handle `fff.nvim` install/update events and call `require("fff.download").download_or_build_binary()` when appropriate. 
- Keep `vim.g.fff` configuration unconditional so plugin settings are available whenever `fff` loads. 
- Add `local fff_ok = pcall(require, "fff")` and gate the `ff`/`fg` keymaps on `fff_ok and not is_vscode` to prevent dead keymaps that error at runtime. 
- Updated `lua/config/plugin_config.lua` accordingly and committed the change.

### Testing
- Inspected the file with `sed -n '1,220p' lua/config/plugin_config.lua` to verify the change was applied (succeeded). 
- Applied the patch and committed with `git commit -m "fix: guard fff keymaps on module availability"` (commit succeeded). 
- Created the follow-up PR via `make_pr` which returned the PR metadata (succeeded). 
- Ran `rg --files -g 'AGENTS.md'` as part of the rollout checks which returned no matches (no files found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da04a711c83279e4cf221766628ec)