### PR TITLE
[audit] Add typescript and tsx treesitter parsers

### DIFF
--- a/lua/config/treesitter.lua
+++ b/lua/config/treesitter.lua
@@ -15,6 +15,16 @@ local parser_repos = {
     { lang = "vimdoc", url = "https://github.com/neovim/tree-sitter-vimdoc" },
     { lang = "javascript", url = "https://github.com/tree-sitter/tree-sitter-javascript" },
     {
+        lang = "typescript",
+        url = "https://github.com/tree-sitter/tree-sitter-typescript",
+        location = "typescript",
+    },
+    {
+        lang = "tsx",
+        url = "https://github.com/tree-sitter/tree-sitter-typescript",
+        location = "tsx",
+    },
+    {
         lang = "markdown",
         url = "https://github.com/tree-sitter-grammars/tree-sitter-markdown",
         location = "tree-sitter-markdown",
@@ -79,6 +89,8 @@ local function ts_install()
             "vim",
             "vimdoc",
             "javascript",
+            "typescript",
+            "tsx",
             "markdown",
             "markdown_inline",
         })


### PR DESCRIPTION
## What

`ts_ls` (TypeScript Language Server) is enabled in `lua/config/plugin_config.lua:67`, but neither `typescript` nor `tsx` appear in the treesitter parser list in `lua/config/treesitter.lua`. This means `.ts` and `.tsx` files get LSP diagnostics and completions but no treesitter syntax highlighting, indentation, or textobject support.

## Where

- `lua/config/treesitter.lua` — `parser_repos` table (lines 7–27) and `ts_install()` language list (lines 71–86)

## Why it matters

- Without the `typescript` parser, treesitter highlighting is absent for `.ts` files. Neovim falls back to regex `syntax on`, which is noticeably inferior.
- `tsx` is a separate grammar (different subdirectory in the same upstream repo) and is needed for `.tsx` React files.
- `scopeline.lua` and `nvim-treesitter-textobjects` (`]f`/`[f`) also silently do nothing for TypeScript buffers without a parser.

## Changes

Both `parser_repos` (for `TSSync latest`) and the `ts_install()` language list (for nvim-treesitter managed installs) receive `typescript` and `tsx`. The upstream grammar lives at `https://github.com/tree-sitter/tree-sitter-typescript` with subdirectories `typescript/` and `tsx/`, following the same `location` pattern already used for `markdown` and `markdown_inline`.

## Testing

After running `:TSSync` (or `:SyncPkgs` + restart), open any `.ts` file and confirm `:TSBufToggle` shows treesitter active and syntax highlighting matches expectations.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Z4oKj41jwPWYT5sMDoCH4)_