### PR TITLE
[audit] fix vim.pack availability check — pcall(require) always false

### DIFF
--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -16,7 +16,7 @@ local package_list = {
     { name = "eldritch", src = "https://github.com/eldritch-theme/eldritch.nvim.git" },
     { name = "solarized-osaka.nvim", src = "https://github.com/craftzdog/solarized-osaka.nvim.git" },
 }
-local vim_pack_ok, _ = pcall(require, "vim.pack")
+local vim_pack_ok = vim.pack ~= nil
 local function sync_packages()
     -- local old_package_dir = os.getenv("HOME") .. "/.config/nvim/pack/plugins/start/"
     local old_package_dir = vim.fn.stdpath("config") .. "/pack/plugins/start/"


### PR DESCRIPTION
## What

`lua/config/plugins.lua:19` uses `pcall(require, "vim.pack")` to detect whether Neovim's built-in package manager is available. This check **always returns `false`** because `vim.pack` is a namespace table on the `vim` global — it is not a Lua module and cannot be loaded with `require`. As a result, the `vim.pack` code path (lines 23–51) and the `packadd` loading loop (lines 95–99) **never execute**, even on Neovim 0.12 where `vim.pack` is fully available.

## Where

`lua/config/plugins.lua:19`

```lua
-- Before (always false — vim.pack is not a require-able module):
local vim_pack_ok, _ = pcall(require, "vim.pack")

-- After (correct namespace presence check):
local vim_pack_ok = vim.pack ~= nil
```

## Why it matters

With Neovim 0.12 (current stable as of 2026-04-22), `vim.pack` is the official built-in package manager. The config already has the full `vim.pack.add` / `vim.pack.update` integration written and the `nvim-pack-lock.json` in place — it just never activates. The broken check means:
- `SyncPkgs` always falls back to the git-clone path
- Plugins installed by `vim.pack` (in `opt/`) are never loaded via `packadd`
- The `PackChanged` autocmd for fff.nvim lazy-loading also never fires

## Change

One-line fix: replace the `pcall(require, ...)` guard with a direct nil-check on the namespace table.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3f3aKUd2eEcuLcB9kwETJ)_