### PR TITLE
[audit] fix scopeline cursor row off-by-one in get_node call

### DIFF
--- a/lua/config/scopeline.lua
+++ b/lua/config/scopeline.lua
@@ -16,7 +16,7 @@ local function draw_scope_lines()
     local buf = vim.api.nvim_get_current_buf()
     vim.api.nvim_buf_clear_namespace(buf, ns_scope_line, 0, -1)
     local cursor = vim.api.nvim_win_get_cursor(0)
-    local ts_node = vim.treesitter.get_node({ pos = { cursor[1], cursor[2] } })
+    local ts_node = vim.treesitter.get_node({ pos = { cursor[1] - 1, cursor[2] } })
     while ts_node do
         if valid_scopes[ts_node:type()] then
             local start_row, start_col, end_row, end_col = ts_node:range()


### PR DESCRIPTION
## What

`lua/config/scopeline.lua:19` passes a 1-based row to `vim.treesitter.get_node()`, which expects a **(0,0)-indexed** position. The cursor row from `vim.api.nvim_win_get_cursor(0)` is 1-indexed, so the node lookup always targets the row **one below** the actual cursor position.

## Where

`lua/config/scopeline.lua:19`

```lua
-- Before (cursor[1] is 1-based, but get_node wants 0-based row):
local ts_node = vim.treesitter.get_node({ pos = { cursor[1], cursor[2] } })

-- After:
local ts_node = vim.treesitter.get_node({ pos = { cursor[1] - 1, cursor[2] } })
```

## Why it matters

For most cursor positions inside a block the wrong row is still within the same scope, so the bug is invisible. It breaks at the **last line of a scope block**: the lookup overshoots to the line after the closing brace, finds no matching scope ancestor, and the scope guide lines disappear one line too early.

The column `cursor[2]` is already 0-based (as returned by `nvim_win_get_cursor`), so only the row needs the `-1` correction.

## Change

One-character fix: `cursor[1]` → `cursor[1] - 1`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3f3aKUd2eEcuLcB9kwETJ)_