### PR TITLE
[audit] Fix visual-mode <leader>lf to format selection only

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -109,7 +109,13 @@ if conform_ok and not is_vscode then
         conform.format()
     end, { desc = "Format buffer" })
     vim.keymap.set("v", "<leader>lf", function()
-        conform.format()
+        conform.format({
+            lsp_format = "fallback",
+            range = {
+                start = vim.api.nvim_buf_get_mark(0, "<"),
+                ["end"] = vim.api.nvim_buf_get_mark(0, ">"),
+            },
+        })
     end, { desc = "Format selection" })
 end
 


### PR DESCRIPTION
## What

The visual-mode `<leader>lf` keymap calls `conform.format()` with no arguments, which formats the **entire buffer** instead of just the selected lines.

## Where

`lua/config/plugin_config.lua:111–113` — the visual-mode conform keymap.

## Why it matters

Neovim exits visual mode before invoking a keymap callback, so by the time `conform.format()` runs the mode is no longer `v`. conform cannot infer the selection automatically without an explicit range. The marks `'<` and `'>` are set by Neovim when visual mode is exited and remain valid until the next visual selection, so reading them inside the callback is the correct approach.

## Change

```lua
-- before
vim.keymap.set("v", "<leader>lf", function()
    conform.format()
end, { desc = "Format selection" })

-- after
vim.keymap.set("v", "<leader>lf", function()
    conform.format({
        lsp_format = "fallback",
        range = {
            start = vim.api.nvim_buf_get_mark(0, "<"),
            ["end"] = vim.api.nvim_buf_get_mark(0, ">"),
        },
    })
end, { desc = "Format selection" })
```

`lsp_format = "fallback"` mirrors `default_format_opts` so the formatter selection logic is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxcUC3MmXHhxVDTXggmnvy)_