### PR TITLE
[audit] Remove WARN-level startup notifications for ui2

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -143,9 +143,6 @@ if not vim.g.vscode then
     local ok, ui2 = pcall(require, "vim._core.ui2")
     if ok then
         pcall(ui2.enable)
-        vim.notify("ui2 enabled", vim.log.levels.WARN)
-    else
-        vim.notify("ui2 disabled (could be old nvim or api shift, check options.lua)", vim.log.levels.WARN)
     end
 end
 


### PR DESCRIPTION
## What

Both the success and failure paths for the experimental `vim._core.ui2` module emit `vim.log.levels.WARN` notifications on every Neovim startup, cluttering the message history.

## Where

`lua/config/options.lua:142–150` — the ui2 enable block.

## Why it matters

- `WARN` implies something needs user attention. These messages are purely informational about an opt-in experiment.
- The `pcall` guards already handle all failure cases silently — the `else` branch notification adds no actionable information.
- On every startup the user sees a yellow flash in the cmdline area even when everything is working correctly.

## Change

```lua
-- before
if not vim.g.vscode then
    local ok, ui2 = pcall(require, "vim._core.ui2")
    if ok then
        pcall(ui2.enable)
        vim.notify("ui2 enabled", vim.log.levels.WARN)
    else
        vim.notify("ui2 disabled (could be old nvim or api shift, check options.lua)", vim.log.levels.WARN)
    end
end

-- after
if not vim.g.vscode then
    local ok, ui2 = pcall(require, "vim._core.ui2")
    if ok then
        pcall(ui2.enable)
    end
end
```

The ui2 enable logic and its pcall safety are preserved; only the noise is removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxcUC3MmXHhxVDTXggmnvy)_