### PR TITLE
[audit] fix WARN→INFO log level for ui2 success notification

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -143,7 +143,7 @@ if not vim.g.vscode then
     local ok, ui2 = pcall(require, "vim._core.ui2")
     if ok then
         pcall(ui2.enable)
-        vim.notify("ui2 enabled", vim.log.levels.WARN)
+        vim.notify("ui2 enabled", vim.log.levels.INFO)
     else
         vim.notify("ui2 disabled (could be old nvim or api shift, check options.lua)", vim.log.levels.WARN)
     end


### PR DESCRIPTION
## What

`options.lua:149` calls `vim.notify("ui2 enabled", vim.log.levels.WARN)` on the **success** path of the `vim._core.ui2` experimental block.

## Where

`lua/config/options.lua:149`

```lua
-- before
vim.notify("ui2 enabled", vim.log.levels.WARN)

-- after
vim.notify("ui2 enabled", vim.log.levels.INFO)
```

## Why it matters

`WARN` level is conventionally rendered in yellow/orange and signals "something may be wrong". Using it for a successful load is semantically backwards and causes unnecessary visual noise on startup for users who have ui2 available. The disabled branch keeps `WARN` since it flags a potential API shift that needs attention.

## Recommended action

Merge as-is — single-character change with no behavioural impact beyond the notification colour/level.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7dYfnWNodsTH3i3wWFkcF)_