### PR TITLE
[audit] Guard nil return from vim.uv.cwd() in statusline current_file()

### DIFF
--- a/lua/config/statusline.lua
+++ b/lua/config/statusline.lua
@@ -29,7 +29,7 @@ local function current_git_branch()
     if not ok then return "" end
     local branch = vim.b.gitsigns_head
     if not branch or branch == "" then return "" end
-    return " %#Git#  " .. branch .. " " .. "%*"
+    return " %#Git#  " .. branch .. " " .. "%*"
 end
 
 local function current_buf_flags()
@@ -99,10 +99,10 @@ local function current_mode()
 end
 
 local filetype_icons = {
-    lua = "",
-    python = "",
+    lua = "",
+    python = "",
     rust = "󱘗",
-    c = "",
+    c = "",
     go = "󰟓",
     javascript = "󰌞",
     typescript = "󰛦",
@@ -127,8 +127,8 @@ local function current_filetype()
 end
 
 local function current_file()
-    local root_path = vim.uv.cwd()
-    local root_dir = root_path:match("[^/]+$")
+    local root_path = vim.uv.cwd() or ""
+    local root_dir = root_path:match("[^/]+$") or ""
     local home_path = vim.fn.expand("%:~")
     local overlap, _ = home_path:find(root_dir)
     local color = "%#File# "
@@ -188,16 +188,16 @@ local function current_diagnostics()
     return " "
         .. "%#StatusLineDiag#"
         .. SOLID_LEFT_ARROW
-        .. "  "
+        .. "  "
         .. _n_ERROR
         .. "┊"
-        .. " "
+        .. " "
         .. _n_WARN
         .. "┊"
         .. "󰋽 "
         .. _n_INFO
         .. "┊"
-        .. " "
+        .. " "
         .. _n_HINT
         .. " "
         .. SOLID_RIGHT_ARROW

--- a/lua/config/statusline.lua
+++ b/lua/config/statusline.lua
@@ -29,7 +29,7 @@ local function current_git_branch()
     if not ok then return "" end
     local branch = vim.b.gitsigns_head
     if not branch or branch == "" then return "" end
-    return " %#Git#  " .. branch .. " " .. "%*"
+    return " %#Git#  " .. branch .. " " .. "%*"
 end
 
 local function current_buf_flags()
@@ -99,10 +99,10 @@ local function current_mode()
 end
 
 local filetype_icons = {
-    lua = "",
-    python = "",
+    lua = "",
+    python = "",
     rust = "󱘗",
-    c = "",
+    c = "",
     go = "󰟓",
     javascript = "󰌞",
     typescript = "󰛦",
@@ -188,16 +188,16 @@ local function current_diagnostics()
     return " "
         .. "%#StatusLineDiag#"
         .. SOLID_LEFT_ARROW
-        .. "  "
+        .. "  "
         .. _n_ERROR
         .. "┊"
-        .. " "
+        .. " "
         .. _n_WARN
         .. "┊"
         .. "󰋽 "
         .. _n_INFO
         .. "┊"
-        .. " "
+        .. " "
         .. _n_HINT
         .. " "
         .. SOLID_RIGHT_ARROW


### PR DESCRIPTION
## What

`lua/config/statusline.lua:130` calls `vim.uv.cwd()` and immediately calls `:match()` on the result without checking for nil:

```lua
-- before
local root_path = vim.uv.cwd()          -- returns string | nil
local root_dir = root_path:match("[^/]+$")  -- crashes if root_path is nil
```

`vim.uv.cwd()` returns `nil` when the process's working directory has been deleted from the filesystem while Neovim is running (e.g. `rm -rf` on a temp project dir). Because `StatusLine()` is evaluated on every redraw, a nil here produces a hard error that breaks the entire statusline.

Same issue one line down: if `root_path` were empty, `root_dir` would itself be nil, causing `home_path:find(root_dir)` to error.

## Where

`lua/config/statusline.lua` — `current_file()` function, lines 130–131.

## Fix

```lua
-- after
local root_path = vim.uv.cwd() or ""
local root_dir = root_path:match("[^/]+$") or ""
```

Both guards are safe: an empty `root_path` causes `home_path == ""` to be true (or falls through to the else branch showing the full home-relative path), which is a reasonable degraded display.

## Why it matters

`StatusLine()` runs on every cursor move. An unguarded nil here silently breaks the statusline until Neovim is restarted — hard to diagnose.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESJxu4oWsgghUPqyTZWzEs)_