### PR TITLE
Add fzf-lua git picker keymaps

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -32,6 +32,10 @@ if ok and not is_vscode then
     vim.keymap.set("n", "<leader>sl", fzf.lines)
     vim.keymap.set("n", "<leader>sb", fzf.buffers)
     vim.keymap.set("n", "<leader>sm", fzf.marks)
+    vim.keymap.set("n", "<leader>gc", fzf.git_commits, { desc = "Git commits (repo)" })
+    vim.keymap.set("n", "<leader>gb", fzf.git_bcommits, { desc = "Git commits (buffer)" })
+    vim.keymap.set("n", "<leader>gB", fzf.git_branches, { desc = "Git branches" })
+    vim.keymap.set("n", "<leader>gs", fzf.git_status, { desc = "Git status" })
 end
 
 -- sneaks


### PR DESCRIPTION
### Motivation
- fzf-lua ships git pickers (`git_commits`, `git_bcommits`, `git_branches`, `git_status`) but they were not mapped in the existing fzf keymap block. 
- Adding these maps fills a browsing gap for commits/branches/status without replacing existing fugitive/gitsigns workflows. 

### Description
- Added four keymaps inside the existing `if ok and not is_vscode then` fzf-lua block in `lua/config/plugin_config.lua`.
- Mappings added: `<leader>gc` → `fzf.git_commits`, `<leader>gb` → `fzf.git_bcommits`, `<leader>gB` → `fzf.git_branches`, and `<leader>gs` → `fzf.git_status`.
- Each mapping includes a `desc` label for discoverability and follows the style of the surrounding keymaps.

### Testing
- Inspected the updated file with `sed -n '1,220p' lua/config/plugin_config.lua` to verify the new mappings are present and correctly placed.
- Printed the mapping region with `nl -ba lua/config/plugin_config.lua | sed -n '24,50p'` to confirm exact lines and descriptions. 
- Verified upstream fzf-lua exposes the mapped pickers via a quick check of the plugin documentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13fcf437948327a069fd4fd090e635)