### PR TITLE
[audit] Fix luals root_markers: nested array causes AND logic, lsp never attaches via .luarc config files

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -49,7 +49,7 @@ if not is_vscode then
     vim.lsp.config["luals"] = {
         cmd = { "lua-language-server" },
         filetypes = { "lua" },
-        root_markers = { { ".luarc.json", ".luarc.jsonc" }, ".git" },
+        root_markers = { ".luarc.json", ".luarc.jsonc", ".git" },
         settings = {
             Lua = {
                 runtime = {


### PR DESCRIPTION
## What

`lua/config/plugin_config.lua:52` — the `root_markers` for the custom `luals` config uses a nested array:

```lua
root_markers = { { ".luarc.json", ".luarc.jsonc" }, ".git" },
```

In `vim.lsp.config`, a nested array means **AND** (every file in the sub-list must exist). So the first entry requires **both** `.luarc.json` and `.luarc.jsonc` to be present simultaneously — a condition that never holds in practice. lua-ls therefore falls back to only matching `.git` as a root marker, which works by accident but means `.luarc.*` files never trigger root detection as intended.

## Where

`lua/config/plugin_config.lua:52`

## Why it matters

If you have a standalone Lua project with a `.luarc.json` but no `.git`, lua-ls won't attach. More subtly, the intent of listing both extensions was clearly "either is sufficient", which is the standard OR pattern used by lspconfig's `root_pattern('.luarc.json', '.luarc.jsonc')`.

## Change

Flatten the sub-array into individual strings — each is checked independently (OR semantics):

```lua
root_markers = { ".luarc.json", ".luarc.jsonc", ".git" },
```

This matches the upstream lspconfig default for `lua_ls`.

https://claude.ai/code/session_01UKkC4bUSCfspiXbmc8AFEB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKkC4bUSCfspiXbmc8AFEB)_