### PR TITLE
[audit] Remove plenary.nvim — unused dep, repo going EOL ~June 2026

### DIFF
--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -12,7 +12,6 @@ local package_list = {
     { name = "conform.nvim", src = "https://github.com/stevearc/conform.nvim.git" },
     { name = "gitsigns.nvim", src = "https://github.com/lewis6991/gitsigns.nvim.git" },
     { name = "obsidian.nvim", src = "https://github.com/obsidian-nvim/obsidian.nvim.git" },
-    { name = "plenary.nvim", src = "https://github.com/nvim-lua/plenary.nvim.git" },
     { name = "dark-theme", src = "https://github.com/stanfish06/dark-theme.git" },
     { name = "rose-pine", src = "https://github.com/rose-pine/neovim.git" },
     { name = "tokyonight", src = "https://github.com/folke/tokyonight.nvim.git" },

--- a/nvim-pack-lock.json
+++ b/nvim-pack-lock.json
@@ -44,10 +44,6 @@
       "rev": "896d4515a7193676aacf8a95239882397fdd6b27",
       "src": "https://github.com/obsidian-nvim/obsidian.nvim.git"
     },
-    "plenary.nvim": {
-      "rev": "74b06c6c75e4eeb3108ec01852001636d85a932b",
-      "src": "https://github.com/nvim-lua/plenary.nvim.git"
-    },
     "rose-pine": {
       "rev": "ff483051a47e27d84bdef47703538df1ed9f4a47",
       "src": "https://github.com/rose-pine/neovim.git"


### PR DESCRIPTION
## What

Remove `plenary.nvim` from `lua/config/plugins.lua` and `nvim-pack-lock.json`.

## Where

- `lua/config/plugins.lua:15` — package list entry
- `nvim-pack-lock.json` — locked rev entry

## Why it matters

**plenary.nvim is effectively EOL.** The repo README now states it will be archived around June 2026, with only critical bug fixes accepted until then and no support after. 

More importantly, it is **no longer needed in this config**: plenary was present solely as a transitive dependency of `obsidian.nvim`, and obsidian.nvim has already dropped plenary as a dependency in a recent release. No file in `lua/` directly `require()`s plenary — verified by grep.

Keeping it means installing and pinning an unmaintained package for no reason.

## Verification

```
$ grep -r "plenary" lua/
lua/config/plugins.lua:    { name = "plenary.nvim", ... }   ← only this line, removed by this PR
```

No other references. Safe to delete.

https://claude.ai/code/session_01UKkC4bUSCfspiXbmc8AFEB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKkC4bUSCfspiXbmc8AFEB)_