### PR TITLE
[audit] fix: pass required `{}` arg to `ui2.enable()` (neovim/neovim#38594)

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -30,8 +30,8 @@ vim.keymap.set("n", "<leader>f", ":find **/*")
 vim.cmd.cnoreabbrev("vimgrep", "vimgrep /pattern/gj **/*")
 vim.keymap.set("n", "<leader>co", "<cmd>copen<CR>", { desc = "[O]pen quickfix list" })
 vim.keymap.set("n", "<leader>cc", "<cmd>cclose<CR>", { desc = "[C]lose quickfix list" })
--- completeion
--- c-n for keyword completeion
+-- completion
+-- c-n for keyword completion
 -- c-e to cancel completion
 vim.keymap.set("i", "<c-space>", "<c-x><c-o>", { desc = "LSP completion" })
 vim.keymap.set("i", "<c-l>", "<c-x><c-l>", { desc = "Line completion" })
@@ -132,7 +132,7 @@ vim.keymap.set("i", "<CR>", function()
     return "<CR>"
 end, { expr = true, noremap = true })
 
--- check full kepmap and dump to a new buffer
+-- check full keymap and dump to a new buffer
 local function which_key()
     vim.cmd("redir @a | silent map | redir END | new | put a")
 end
@@ -142,7 +142,8 @@ vim.api.nvim_create_user_command("DescribeKey", which_key, {})
 if not vim.g.vscode then
     local ok, ui2 = pcall(require, "vim._core.ui2")
     if ok then
-        pcall(ui2.enable)
+        -- {} required: calling enable() without args is a documented Neovim bug (neovim/neovim#38594)
+        pcall(ui2.enable, {})
         vim.notify("ui2 enabled", vim.log.levels.INFO)
     else
         vim.notify("ui2 disabled (could be old nvim or api shift, check options.lua)", vim.log.levels.WARN)


### PR DESCRIPTION
## What

`lua/config/options.lua:148` calls `pcall(ui2.enable)` with no arguments. Calling `vim._core.ui2.enable()` without an empty table `{}` is a **documented Neovim bug** ([neovim/neovim#38594](https://github.com/neovim/neovim/issues/38594)) — the function panics or produces undefined behavior depending on the nightly version.

## Where

`lua/config/options.lua` — the `vim._core.ui2` experimental block.

**Before:**
```lua
pcall(ui2.enable)
```

**After:**
```lua
-- {} required: calling enable() without args is a documented Neovim bug (neovim/neovim#38594)
pcall(ui2.enable, {})
```

## Why it matters

Without `{}`, enabling ui2 may silently error (caught by `pcall`) but then fail to actually activate the new message/cmdline UI, meaning the feature never turns on despite reporting "ui2 enabled".

## Notes

- This does not affect whether to keep or remove the ui2 block (see issue #86 for that discussion).
- Also fixes two minor typos in adjacent comments (`completeion` → `completion`, `kepmap` → `keymap`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEMY9QLXM78bt4EwYAoc1y)_