### PR TITLE
[audit] conform: add typescriptreact/javascriptreact formatters

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -106,7 +106,9 @@ if conform_ok and not is_vscode then
             lua = { "stylua" },
             python = { "ruff_format" },
             javascript = { "prettier" },
+            javascriptreact = { "prettier" },
             typescript = { "prettier" },
+            typescriptreact = { "prettier" },
         },
     })
     vim.keymap.set("n", "<leader>lf", function()


### PR DESCRIPTION
## What

`conform.nvim` is configured to format `javascript` and `typescript` with `prettier`, but the React variants — `typescriptreact` (`.tsx`) and `javascriptreact` (`.jsx`) — were missing from `formatters_by_ft`.

## Where

`lua/config/plugin_config.lua:105-110`

```lua
-- before
formatters_by_ft = {
    lua = { "stylua" },
    python = { "ruff_format" },
    javascript = { "prettier" },
    typescript = { "prettier" },
},

-- after
formatters_by_ft = {
    lua = { "stylua" },
    python = { "ruff_format" },
    javascript = { "prettier" },
    javascriptreact = { "prettier" },
    typescript = { "prettier" },
    typescriptreact = { "prettier" },
},
```

## Why it matters

Hitting `<leader>lf` in a `.tsx` or `.jsx` file silently did nothing — Neovim reports the filetype as `typescriptreact`/`javascriptreact`, not `typescript`/`javascript`. prettier handles both identically, so this is a pure omission with no configuration risk.

## Recommended action

Merge as-is. No behaviour change for existing filetypes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBtiUebD5QFUnL62vtEcTp)_