### PR TITLE
Expand scopeline valid_scopes to support Rust/TS/Go/Python/Lua nodes

### DIFF
--- a/lua/config/scopeline.lua
+++ b/lua/config/scopeline.lua
@@ -1,10 +1,29 @@
 -- scope line
 local valid_scopes = {
+    -- C / C++ / Go / JS / TS
     ["function_declaration"] = true,
     ["function_definition"] = true,
+    ["method_declaration"] = true,
     ["if_statement"] = true,
     ["for_statement"] = true,
     ["while_statement"] = true,
+    -- Rust
+    ["function_item"] = true,
+    ["impl_item"] = true,
+    ["match_expression"] = true,
+    ["closure_expression"] = true,
+    -- TypeScript / JavaScript
+    ["arrow_function"] = true,
+    ["method_definition"] = true,
+    ["class_declaration"] = true,
+    -- Python
+    ["with_statement"] = true,
+    ["try_statement"] = true,
+    ["match_statement"] = true,
+    -- Lua
+    ["do_statement"] = true,
+    -- Shared
+    ["type_declaration"] = true,
 }
 local ns_scope_line = vim.api.nvim_create_namespace("scope_line")
 local function char_at(row, col)


### PR DESCRIPTION
### Motivation

- The existing `valid_scopes` table in `lua/config/scopeline.lua` only covered a C-style subset of Tree-sitter node types which caused scope lines to be missed for many common constructs. 
- Configured languages (Rust, TypeScript/JS, Go, Python, Lua) use additional node types such as `function_item`, `arrow_function`, and `with_statement` which were not present in the allow-list. 
- Extending the table improves scope-line coverage across the editor setup without changing rendering logic.

### Description

- Extended the `valid_scopes` table in `lua/config/scopeline.lua` to include additional node types for C/Go/JS/TS, Rust, TypeScript/JavaScript, Python, Lua, and shared declarations (examples: `method_declaration`, `function_item`, `arrow_function`, `with_statement`, `do_statement`, `type_declaration`).
- Kept `draw_scope_lines()` and all drawing logic unchanged so the change is strictly a data/allow-list expansion keyed by `ts_node:type()`.
- The change is localized to the single file `lua/config/scopeline.lua` and does not add new runtime dependencies.

### Testing

- Applied the update using a scripted edit (small Python snippet) which completed successfully. 
- Inspected the modified file contents with `nl -ba lua/config/scopeline.lua | sed -n '1,70p'` to verify the new entries were present. 
- Created a follow-up PR record via `make_pr` summarizing this expansion, and the automated steps above completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1740549a1c8327a7eb8feb75c57133)