### PR TITLE
feat(sneak): configure vim-sneak with label mode and smartcase

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -38,8 +38,10 @@ if ok and not is_vscode then
     vim.keymap.set("n", "<leader>gs", fzf.git_status, { desc = "Git status" })
 end
 
--- sneaks
+-- sneaks — intentionally remaps s/S to 2-char forward/backward seek motion
 -- git clone --depth 1 https://github.com/justinmk/vim-sneak ~/.config/nvim/pack/plugins/start/vim-sneak
+vim.g["sneak#label"] = 1       -- label mode: shows jump targets (EasyMotion-style)
+vim.g["sneak#use_ic_scs"] = 1  -- respect smartcase
 
 -- lsp
 -- git clone https://github.com/neovim/nvim-lspconfig ~/.config/nvim/pack/nvim/start/nvim-lspconfig

--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -5,7 +5,7 @@ local package_list = {
     { name = "fzf-lua", src = "https://github.com/ibhagwan/fzf-lua.git" },
     { name = "fff.nvim", src = "https://github.com/dmtrKovalenko/fff.nvim", lazy = true },
     { name = "nvim-lspconfig", src = "https://github.com/neovim/nvim-lspconfig" },
-    { name = "sneaks.vim", src = "https://github.com/justinmk/vim-sneak" },
+    { name = "sneaks.vim", src = "https://github.com/justinmk/vim-sneak" }, -- remaps s/S intentionally; configured in plugin_config.lua
     { name = "fugitive.vim", src = "https://tpope.io/vim/fugitive.git" },
     { name = "nvim-treesitter", src = "https://github.com/nvim-treesitter/nvim-treesitter.git" },
     { name = "nvim-treesitter-textobjects", src = "https://github.com/nvim-treesitter/nvim-treesitter-textobjects.git" },


### PR DESCRIPTION
Enable label mode and smartcase for vim-sneak so the plugin provides visible jump targets (`sneak#label`) and respects case settings (`sneak#use_ic_scs`). Adds comments documenting the intentional s/S remapping near both the plugin declaration and config block.

Closes #100

Generated with [Claude Code](https://claude.ai/code)