### PR TITLE
Remove conflicting gr LSP keymap

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -36,7 +36,7 @@ vim.keymap.set("n", "<leader>cc", "<cmd>cclose<CR>", { desc = "[C]lose quickfix 
 vim.keymap.set("i", "<c-space>", "<c-x><c-o>", { desc = "LSP completion" })
 vim.keymap.set("i", "<c-l>", "<c-x><c-l>", { desc = "Line completion" })
 vim.keymap.set("i", "<c-f>", "<c-x><c-f>", { desc = "File completion" })
--- lsp keymaps: gd / gr set buffer-local in plugin_config.lua via LspAttach
+-- lsp keymap: gd set buffer-local in plugin_config.lua via LspAttach
 -- todo: it is a bit annoying to have repeated entries when multiple lsps exist, should either dedup or show sources
 
 -- diagnostics: tag source so multiple LSPs are distinguishable

--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -111,7 +111,6 @@ if not is_vscode then
             end
             local opts = { buffer = ev.buf }
             vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
-            vim.keymap.set("n", "gr", vim.lsp.buf.references, opts)
         end,
     })
 end


### PR DESCRIPTION
### Motivation
- The buffer-local `gr` mapping shadows Neovim 0.11+ built-in `gr*` LSP mappings (`grr`/`grn`/`gra`/`gri`) and makes those built-ins unreachable when `gr` is set.

### Description
- Removed the `vim.keymap.set("n", "gr", vim.lsp.buf.references, opts)` mapping from `lua/config/plugin_config.lua` to avoid shadowing the built-in `gr*` keys.
- Updated the comment in `lua/config/options.lua` to reflect that only `gd` remains set buffer-local via `LspAttach`.

### Testing
- Ran `git diff --check`, which completed successfully. 
- Attempted `nvim --headless -u init.lua '+quit'`, but `nvim` is not installed in the environment so this check could not be run. 
- Attempted to validate the Lua files with `lua -e 'assert(loadfile("lua/config/plugin_config.lua")); assert(loadfile("lua/config/options.lua"))'`, but `lua` is not installed in the environment so this check could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186ff6148883278339de2e41aac262)