### PR TITLE
[audit] Fix PackChanged autocmd — must be `User PackChanged` not top-level event

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -121,7 +121,8 @@ end
 
 -- fff
 local fff_ok, _ = pcall(function()
-    vim.api.nvim_create_autocmd("PackChanged", {
+    vim.api.nvim_create_autocmd("User", {
+        pattern = "PackChanged",
         callback = function(ev)
             local name, kind = ev.data.spec.name, ev.data.kind
             if name == "fff.nvim" and (kind == "install" or kind == "update") then


### PR DESCRIPTION
## What

`lua/config/plugin_config.lua` line 124 registered `"PackChanged"` as a top-level autocmd event. That event name does not exist — `vim.pack` fires it as a `User` autocmd with `pattern = "PackChanged"`.

## Where

`lua/config/plugin_config.lua` — the `fff.nvim` setup block (previously line 124, now fixed).

## Why it matters

Because the autocmd never fired, `require("fff.download").download_or_build_binary()` was never called after `SyncPkgs` installed or updated `fff.nvim`. The fff binary was silently never built, so `fff.find_files()` and `fff.live_grep()` would error at runtime.

## Fix

```diff
-vim.api.nvim_create_autocmd("PackChanged", {
-    callback = function(ev)
+vim.api.nvim_create_autocmd("User", {
+    pattern = "PackChanged",
+    callback = function(ev)
```

Closes #117

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrCYA1axf2scmiJvRQny91)_