### PR TITLE
[audit] Fix formatoptions being silently overridden by filetype plugins

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -102,6 +102,14 @@ vim.o.foldtext = ""
 
 -- editing
 vim.o.formatoptions = "rqnl1j"
+-- ftplugins use :setlocal to override formatoptions, wiping the global value.
+-- This autocmd re-applies the desired flags after every filetype plugin runs.
+vim.api.nvim_create_autocmd("FileType", {
+    pattern = "*",
+    callback = function()
+        vim.opt_local.formatoptions = "rqnl1j"
+    end,
+})
 vim.o.infercase = true
 vim.o.spelloptions = "camel"
 vim.o.virtualedit = "block"


### PR DESCRIPTION
## What

`lua/config/options.lua` sets custom `formatoptions` via `vim.o` (global default):

```lua
vim.o.formatoptions = "rqnl1j"
```

`formatoptions` is a **window-local** option. Filetype plugins (Neovim's built-in `ftplugin/*.lua` files) use `:setlocal formatoptions+=…` when a buffer's filetype is detected, which **replaces the local value** and discards the user's custom flags. In practice, the user's flags were only honoured for buffers with no recognized filetype.

## Why it matters

The user's flags that were being silently dropped:
- `r` — auto-insert comment leader (`//`, `--`, `#`) when pressing Enter in Insert mode
- `n` — recognize and reformat numbered/bulleted lists (depends on `formatlistpat`)  
- `l` — don't auto-break long lines in Insert mode
- `1` — don't break a line before a single-character word

`n` + `formatlistpat` (the custom list pattern at line 114) are a matched pair. Without `n` surviving into actual file buffers, `gq`/`gqip` on Markdown or code comments produces garbage line-breaking.

## Fix

Add a `FileType *` autocmd that re-applies the value after every filetype plugin runs. Because user config is loaded after Neovim's runtime, user-registered autocmds fire after the built-in ftplugin loader within the same `FileType` event, so this wins the ordering race reliably.

```lua
vim.api.nvim_create_autocmd("FileType", {
    pattern = "*",
    callback = function()
        vim.opt_local.formatoptions = "rqnl1j"
    end,
})
```

## Files changed

- `lua/config/options.lua` — add the `FileType` autocmd immediately after the `vim.o.formatoptions` line

## References

- [Neovim discussion: Set global 'formatoptions' that doesn't get overwritten by runtime files](https://github.com/neovim/neovim/discussions/26885)
- [Neovim discussion: Why change 'formatoptions' in filetype plugins?](https://github.com/neovim/neovim/discussions/26908)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6UQxi5K5RAfo8aeQbrqF8)_