### PR TITLE
[audit] treesitter.lua: add augroup to autocmds to prevent duplicate registration

### DIFF
--- a/lua/config/treesitter.lua
+++ b/lua/config/treesitter.lua
@@ -158,7 +158,10 @@ local function ts_highlight()
         ts_highlight_active[bufnr] = true
     end
 end
+
+local treesitter_aug = vim.api.nvim_create_augroup("Treesitter", { clear = true })
 vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
+    group = treesitter_aug,
     callback = function(ev) ts_highlight_active[ev.buf] = nil end,
 })
 
@@ -181,6 +184,7 @@ vim.api.nvim_create_user_command("TSBufToggle", ts_highlight, {})
 -- TSSync latest will pull and build latest parsers (but sitll use nvim-treesitter's query files)
 vim.api.nvim_create_user_command("TSSync", ts_update, { nargs = "?" })
 vim.api.nvim_create_autocmd("FileType", {
+    group = treesitter_aug,
     pattern = { "*" },
     callback = function()
         local bufnr = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
## What

Assign both autocmds in `lua/config/treesitter.lua` to a named `"Treesitter"` augroup with `clear = true`.

## Where

`lua/config/treesitter.lua` — the `BufDelete`/`BufWipeout` handler (line 161) and the `FileType` handler (line 183) both lacked a `group` attribute.

## Why it matters

Without a group, each autocmd accumulates a fresh registration every time the file is re-sourced (e.g. after `:luafile %`, a hot-reload workflow, or future tooling). A duplicate `FileType *` handler would try to start treesitter twice per buffer open, and a duplicate `BufDelete`/`BufWipeout` handler would nil the highlight-state table entry twice — harmless today but a silent source of confusion when debugging autocmd behaviour.

`scopeline.lua` already does this correctly with `vim.api.nvim_create_augroup("ScopeLines", { clear = true })`. This change brings `treesitter.lua` in line with the same pattern.

## Change

```diff
-vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
+local treesitter_aug = vim.api.nvim_create_augroup("Treesitter", { clear = true })
+vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
+    group = treesitter_aug,
     callback = function(ev) ts_highlight_active[ev.buf] = nil end,
 })
 …
 vim.api.nvim_create_autocmd("FileType", {
+    group = treesitter_aug,
     pattern = { "*" },
```

No functional change on a normal single-source startup.

---
_Generated by [Claude Code](https://claude.ai/code/session_019VxcWG6Cs1DnSr2EtkCQTA)_