### PR TITLE
[audit] Fix fff.nvim PackChanged listener — use User autocmd pattern

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -147,7 +147,8 @@ end
 
 -- fff
 local fff_ok, _ = pcall(function()
-    vim.api.nvim_create_autocmd("PackChanged", {
+    vim.api.nvim_create_autocmd("User", {
+        pattern = "PackChanged",
         callback = function(ev)
             local name, kind = ev.data.spec.name, ev.data.kind
             if name == "fff.nvim" and (kind == "install" or kind == "update") then


### PR DESCRIPTION
## What

`vim.pack` fires a `User` event with pattern `PackChanged`, not a first-class `PackChanged` event. The autocmd in `lua/config/plugin_config.lua` was listening for `"PackChanged"` as the event name — which is a non-existent event and never fires. As a result, `fff.nvim`'s binary was never downloaded after `SyncPkgs` installed or updated the plugin.

## Where

`lua/config/plugin_config.lua` — the `fff` section, around line 150.

## Why it matters

Without this fix, `require("fff.download").download_or_build_binary()` is never called automatically. The user would need to manually invoke the download after every `SyncPkgs` run.

## Change

```diff
-    vim.api.nvim_create_autocmd("PackChanged", {
+    vim.api.nvim_create_autocmd("User", {
+        pattern = "PackChanged",
```

Fixes #117.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXmvD8kGQYCVDV14SpsQSh)_