### PR TITLE
[audit] Fix deprecated `buffer` key in vim.keymap.set opts (Neovim 0.12)

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -109,7 +109,7 @@ if not is_vscode then
                     vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
                 end)
             end
-            local opts = { buf = ev.buf }
+            local opts = vim.fn.has('nvim-0.12') == 1 and { buf = ev.buf } or { buffer = ev.buf }
             vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
         end,
     })

--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -109,7 +109,7 @@ if not is_vscode then
                     vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
                 end)
             end
-            local opts = { buffer = ev.buf }
+            local opts = { buf = ev.buf }
             vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
         end,
     })


### PR DESCRIPTION
## What

Neovim 0.12 deprecates the `buffer` option key in `vim.keymap.set()` / `vim.keymap.del()` in favour of `buf`.

## Where

`lua/config/plugin_config.lua:112` — inside the `LspAttach` autocmd callback:

```lua
-- before
local opts = { buffer = ev.buf }

-- after
local opts = { buf = ev.buf }
```

## Why it matters

The config targets Neovim 0.12+ (uses `vim.pack`, `vim.lsp.config`, `vim.lsp.enable`, `completeopt = "fuzzy"`, `winborder`, all 0.11/0.12 APIs). Using the deprecated `buffer` key will produce a deprecation warning in 0.12 and will stop working in a future release once the key is removed.

## Change

One-line rename: `buffer = ev.buf` → `buf = ev.buf` in the `opts` table passed to `vim.keymap.set("n", "gd", ...)`.

## References

- Neovim 0.12 release notes: `:help news-0.12` → vim.keymap section
- `deprecated.txt`: `vim.keymap.set()`/`del()` `buffer` option → `buf`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJNb6QtQTFur5vCNVVccfX)_