### PR TITLE
[audit] fix foldmethod: use 'expr' so treesitter foldexpr is consulted

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -97,7 +97,7 @@ vim.o.listchars = "extends:…,nbsp:␣,precedes:…,tab:> "
 
 -- folding
 vim.o.foldlevel = 10
-vim.o.foldmethod = "indent"
+vim.o.foldmethod = "expr"
 vim.o.foldexpr = "v:lua.vim.treesitter.foldexpr()"
 vim.o.foldnestmax = 10
 vim.o.foldtext = ""


### PR DESCRIPTION
## What

`lua/config/options.lua:100` sets `foldmethod = "indent"` while `foldexpr` is pointed at `vim.treesitter.foldexpr()`. These two settings contradict each other.

## Where

`lua/config/options.lua` lines 100–101:

```lua
vim.o.foldmethod = "indent"                          -- ← wrong
vim.o.foldexpr  = "v:lua.vim.treesitter.foldexpr()"
```

## Why it matters

Neovim only calls `foldexpr` when `foldmethod = "expr"`. With `foldmethod = "indent"` the expression is set but **never evaluated** — all folding falls back to dumb indent-counting. This silently breaks every treesitter-aware fold boundary (e.g. multi-line if/match arms, docstrings, etc.).

## Change

```diff
-vim.o.foldmethod = "indent"
+vim.o.foldmethod = "expr"
```

One character change, no behaviour regression for any other option.

---
_Generated by [Claude Code](https://claude.ai/code/session_014eiycWG5KeoanDfLHDC825)_