### PR TITLE
[audit] replace deprecated vim.lsp.stop_client() with client:stop()

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -119,7 +119,11 @@ if not is_vscode then
     vim.api.nvim_create_user_command("LspToggle", function(opts)
         local name = opts.args
         for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
-            client:stop()
+            if vim.fn.has('nvim-0.12') == 1 then
+                client:stop()
+            else
+                vim.lsp.stop_client(client.id)
+            end
             return
         end
         vim.lsp.enable(name)

--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -119,8 +119,7 @@ if not is_vscode then
     vim.api.nvim_create_user_command("LspToggle", function(opts)
         local name = opts.args
         for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
-            -- TODO: replace with Client:stop() after current api deprecate
-            vim.lsp.stop_client(client.id)
+            client:stop()
             return
         end
         vim.lsp.enable(name)


### PR DESCRIPTION
## What

`lua/config/plugin_config.lua` — the `LspToggle` command — calls the deprecated `vim.lsp.stop_client(client.id)`. The code already has a `-- TODO` comment flagging this.

## Where

`lua/config/plugin_config.lua` lines 121–124:

```lua
for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
    -- TODO: replace with Client:stop() after current api deprecate
    vim.lsp.stop_client(client.id)
    return
end
```

## Why it matters

`vim.lsp.stop_client()` was deprecated in Neovim 0.12 in favour of calling `stop()` directly on the client object. Keeping the old form will emit deprecation warnings on every `:LspToggle` invocation once Neovim completes the transition.

## Change

```diff
 for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
-    -- TODO: replace with Client:stop() after current api deprecate
-    vim.lsp.stop_client(client.id)
+    client:stop()
     return
 end
```

Drops the resolved TODO comment as well.

---
_Generated by [Claude Code](https://claude.ai/code/session_014eiycWG5KeoanDfLHDC825)_