### PR TITLE
[audit] fix LspAttach gd keymap: remove invalid `buf` key, use `buffer` for all nvim versions

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -112,8 +112,7 @@ if not is_vscode then
                     vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
                 end)
             end
-            local opts = vim.fn.has('nvim-0.12') == 1 and { buf = ev.buf } or { buffer = ev.buf }
-            vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
+            vim.keymap.set("n", "gd", vim.lsp.buf.definition, { buffer = ev.buf })
         end,
     })
     vim.api.nvim_create_user_command("LspToggle", function(opts)


### PR DESCRIPTION
## What

`lua/config/plugin_config.lua:115` had a version-guarded opts table for the `gd` buffer-local keymap that contained a bug on two levels:

```lua
-- before
local opts = vim.fn.has('nvim-0.12') == 1 and { buf = ev.buf } or { buffer = ev.buf }
vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
```

**Problem 1 — invalid key `buf`**: `vim.keymap.set` accepts `buffer` for a buffer-local keymap, not `buf`. Passing `{ buf = ev.buf }` is silently ignored, so on nvim-0.12+ `gd` was registered as a *global* map rather than buffer-local — it would apply in every buffer regardless of which LSP was attached.

**Problem 2 — inverted condition**: the branch that returned the *wrong* key (`buf`) was guarded by `has('nvim-0.12') == 1`, i.e. the newest code path was also the broken one.

## Where

`lua/config/plugin_config.lua`, lines 115–116 (inside the `LspAttach` autocmd callback).

## Fix

```lua
-- after
vim.keymap.set("n", "gd", vim.lsp.buf.definition, { buffer = ev.buf })
```

`buffer` is the correct, documented key for buffer-local keymaps in `vim.keymap.set` and has been so since Neovim 0.7. The version check is unnecessary and removed.

## Risk

Low — this restores the *intended* behaviour (buffer-local `gd`). The only visible change is that `gd` no longer leaks into buffers that have no LSP attached.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEz6SDiKGg7MYaEVTZuAvk)_