### PR TITLE
[audit] fix: foldmethod "indent" → "expr" to activate treesitter folding

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -97,7 +97,7 @@ vim.o.listchars = "extends:…,nbsp:␣,precedes:…,tab:> "
 
 -- folding
 vim.o.foldlevel = 10
-vim.o.foldmethod = "indent"
+vim.o.foldmethod = "expr"
 vim.o.foldexpr = "v:lua.vim.treesitter.foldexpr()"
 vim.o.foldnestmax = 10
 vim.o.foldtext = ""


### PR DESCRIPTION
## What

`lua/config/options.lua:100` sets `foldmethod = "indent"` but the very next line configures a treesitter `foldexpr`. Because Neovim only evaluates `foldexpr` when `foldmethod = "expr"`, the treesitter fold expression has been silently dead — folding was indent-based all along.

```lua
-- before
vim.o.foldmethod = "indent"
vim.o.foldexpr   = "v:lua.vim.treesitter.foldexpr()"  -- never evaluated

-- after
vim.o.foldmethod = "expr"
vim.o.foldexpr   = "v:lua.vim.treesitter.foldexpr()"  -- now active
```

## Where

`lua/config/options.lua:100`

## Why it matters

With `foldmethod = "indent"`, folds are purely whitespace-based and have no awareness of language syntax — mismatched indentation (e.g. Python docstrings, closing braces) creates wrong fold boundaries. `foldmethod = "expr"` with `vim.treesitter.foldexpr()` uses the AST for correct, language-aware fold boundaries.

`foldlevel = 10` is already set, so switching to `"expr"` will not collapse any currently-open folds — behaviour is identical on startup, but `:set foldmethod?` will now report `expr` and `zc`/`za` will fold on correct AST boundaries.

## Note on `foldnestmax`

`foldnestmax` only applies to `indent` and `syntax` methods; it is silently ignored by `expr`. The existing `vim.o.foldnestmax = 10` line becomes a harmless no-op after this change.

## Recommended action

Merge. One-line change, zero risk of breaking existing open-fold behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSKaSHE2Te8vKLCN7N9dUz)_