### PR TITLE
[audit] Fix scope-line virtual text highlight: {} → "NonText"

### DIFF
--- a/lua/config/scopeline.lua
+++ b/lua/config/scopeline.lua
@@ -52,7 +52,7 @@ local function draw_scope_lines()
                         ns_scope_line,
                         i,
                         start_col,
-                        { virt_text = { { "|", {} } }, virt_text_pos = "overlay" }
+                        { virt_text = { { "|", "NonText" } }, virt_text_pos = "overlay" }
                     )
                 end
             end


### PR DESCRIPTION
## What

`lua/config/scopeline.lua:55` passes an empty table `{}` as the highlight group for the virtual `|` scope-line character:

```lua
-- before
{ virt_text = { { "|", {} } }, virt_text_pos = "overlay" }
```

`nvim_buf_set_extmark` expects the second element of each `virt_text` chunk to be a highlight group name (string) or list of group names. An empty table means "no highlight", so the `|` inherits the foreground colour of whatever text sits at that screen column — making scope lines nearly invisible in most themes.

## Fix

```lua
-- after
{ virt_text = { { "|", "NonText" } }, virt_text_pos = "overlay" }
```

`NonText` is the standard Neovim group for non-printable/virtual characters — consistently dimmed across all built-in and popular third-party themes.

## Why

Scope lines are only useful when they are distinguishable. With `{}` they silently blend into code; with `"NonText"` they are visually present without being distracting.

Closes #134

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5bBasPMuFBMqyRj2cXEc4)_