### PR TITLE
Integrate diffview.nvim git diff workflow

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -201,6 +201,16 @@ if fff_ok then
     end
 end
 
+-- diffview
+local diffview_ok, diffview = pcall(require, "diffview")
+if diffview_ok and not is_vscode then
+    diffview.setup({
+        use_icons = false,
+    })
+    vim.keymap.set("n", "<leader>gd", "<cmd>DiffviewOpen<CR>", { desc = "Git diff (working tree)" })
+    vim.keymap.set("n", "<leader>gh", "<cmd>DiffviewFileHistory %<CR>", { desc = "Git file history" })
+end
+
 -- gitsigns
 local gitsigns_ok, gitsigns = pcall(require, "gitsigns")
 if gitsigns_ok and not is_vscode then

--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -12,6 +12,7 @@ local package_list = {
     { name = "nvim-lspconfig", src = "https://github.com/neovim/nvim-lspconfig" },
     { name = "sneaks.vim", src = "https://github.com/justinmk/vim-sneak" }, -- remaps s/S intentionally
     { name = "fugitive.vim", src = "https://tpope.io/vim/fugitive.git" },
+    { name = "diffview.nvim", src = "https://github.com/sindrets/diffview.nvim.git" },
     { name = "nvim-treesitter", src = "https://github.com/nvim-treesitter/nvim-treesitter.git" },
     {
         name = "nvim-treesitter-textobjects",


### PR DESCRIPTION
### Motivation

- Provide a visual git diff and per-file history view to complement the repository's existing git workflow (fugitive, gitsigns, fzf-lua). 
- Add a lightweight diffviewer without introducing an extra devicons dependency.

### Description

- Add `sindrets/diffview.nvim` to `lua/config/plugins.lua` so it is managed by the existing package list. 
- Add guarded setup for `diffview` in `lua/config/plugin_config.lua` that calls `diffview.setup({ use_icons = false })`. 
- Add keymaps `<leader>gd` to run `:DiffviewOpen` and `<leader>gh` to run `:DiffviewFileHistory %`, and guard the config with `pcall(require, "diffview")` and `not is_vscode`.

### Testing

- Ran `git diff --check`, which returned no issues. 
- Attempted to run `nvim --headless -u NONE -c 'lua dofile("lua/config/plugins.lua")' -c 'qa'`, but it failed because `nvim` is not installed in the environment. 
- No runtime errors were observed when adding the code and committing the changes in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25bc5253b0832782f3f0dc990ba74c)