### PR TITLE
[audit] Drop vim.lsp.stop_client dead branch + fix PackChanged User event

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -122,11 +122,7 @@ if not is_vscode then
     vim.api.nvim_create_user_command("LspToggle", function(opts)
         local name = opts.args
         for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
-            if vim.fn.has('nvim-0.12') == 1 then
-                client:stop()
-            else
-                vim.lsp.stop_client(client.id)
-            end
+            client:stop()
             return
         end
         vim.lsp.enable(name)
@@ -171,7 +167,8 @@ end
 
 -- fff
 local fff_ok, _ = pcall(function()
-    vim.api.nvim_create_autocmd("PackChanged", {
+    vim.api.nvim_create_autocmd("User", {
+        pattern = "PackChanged",
         callback = function(ev)
             local name, kind = ev.data.spec.name, ev.data.kind
             if name == "fff.nvim" and (kind == "install" or kind == "update") then


### PR DESCRIPTION
## What

Two mechanical fixes in `lua/config/plugin_config.lua`.

---

### 1. Remove dead `vim.lsp.stop_client()` branch in `:LspToggle`

**Where:** `lua/config/plugin_config.lua` — `LspToggle` user command

**Change:** Removed the `vim.fn.has('nvim-0.12')` version check and `else vim.lsp.stop_client(client.id)` branch. Now unconditionally calls `client:stop()`.

**Why:** `vim.lsp.stop_client()` is deprecated in Neovim 0.12. The config already requires 0.12+ (`vim.pack`, `vim.lsp.config`, `vim.lsp.enable` are all 0.12 APIs), so the `else` branch was unreachable dead code pointing at a deprecated API. The previous `audit/lsp-stop-client` branch had added the check for backward compat; since that compat window is closed, this removes the dead path.

---

### 2. Fix `PackChanged` autocmd — use `User` event with pattern (closes #117)

**Where:** `lua/config/plugin_config.lua` — fff.nvim `PackChanged` handler

**Change:** `nvim_create_autocmd("PackChanged", ...)` → `nvim_create_autocmd("User", { pattern = "PackChanged", ... })`.

**Why:** `vim.pack` fires lifecycle notifications as `User` events, not top-level Neovim events. The old registration created an autocmd that never fired, so `fff.download.download_or_build_binary()` was never called after `:SyncPkgs`. The fff.nvim native binary was never built, causing `find_files()` / `live_grep()` to fail silently at runtime.

## Test plan

- [ ] `:LspToggle <name>` on attached client → stops; run again → re-enables
- [ ] `:SyncPkgs` → fff.nvim binary built/downloaded; `:lua require("fff").find_files()` works

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKLs5mTzivoSuheFGFWPxC)_