### PR TITLE
[audit] Normalize vim.lsp.config call style for luals and sourcekit

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -61,7 +61,7 @@ end
 -- after v12, neovim will have built-in package manager
 -- lua
 if not is_vscode then
-    vim.lsp.config["luals"] = {
+    vim.lsp.config("luals", {
         cmd = { "lua-language-server" },
         filetypes = { "lua" },
         root_markers = { ".luarc.json", ".luarc.jsonc", ".git" },
@@ -72,7 +72,7 @@ if not is_vscode then
                 },
             },
         },
-    }
+    })
     -- brew install lua-language-server
     vim.lsp.enable("luals")
     -- uv tool install pyright
@@ -98,11 +98,11 @@ if not is_vscode then
     -- go
     vim.lsp.enable("gopls")
     -- swift
-    vim.lsp.config["sourcekit"] = {
+    vim.lsp.config("sourcekit", {
         cmd = { "sourcekit-lsp" },
         filetypes = { "swift", "objective-c", "objective-cpp" },
         root_markers = { "Package.swift", "compile_commands.json", ".git" },
-    }
+    })
     vim.lsp.enable("sourcekit")
     vim.api.nvim_create_autocmd("LspAttach", {
         callback = function(ev)


### PR DESCRIPTION
## What

Normalize `vim.lsp.config` call style: replace bracket-index assignment with the documented function-call form for `luals` and `sourcekit`.

## Where

`lua/config/plugin_config.lua`
- Lines 64–75: `vim.lsp.config["luals"] = {…}` → `vim.lsp.config("luals", {…})`
- Lines 101–105: `vim.lsp.config["sourcekit"] = {…}` → `vim.lsp.config("sourcekit", {…})`

`pyright` on line 79 already used the function-call form — this makes all three consistent.

## Why

`vim.lsp.config` has a metatable that accepts both table-index and function-call assignment, so there is no current runtime difference. But the documented API since Neovim 0.11 is `vim.lsp.config("name", spec)`. The mixed style is confusing when reading the file and increases the risk that a future Neovim cleanup removes the table-assignment alias.

## Test plan

- [ ] `:lua vim.lsp.get_clients()` shows `luals` after opening a `.lua` file
- [ ] `:lua vim.lsp.get_clients()` shows `sourcekit` after opening a `.swift` file (macOS only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8jrJVQBJmgdbZnCY86mXc)_