### PR TITLE
[deps] fff.nvim: bump version pin from 0.9.0 to 0.9.4

### DIFF
--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -7,7 +7,7 @@ local package_list = {
         name = "fff.nvim",
         src = "https://github.com/dmtrKovalenko/fff.nvim",
         lazy = true,
-        version = vim.version.range("0.9.0"),
+        version = vim.version.range("0.9.4"),
     }, -- this package breaks frequently, specify version
     { name = "nvim-lspconfig", src = "https://github.com/neovim/nvim-lspconfig" },
     { name = "sneaks.vim", src = "https://github.com/justinmk/vim-sneak" }, -- remaps s/S intentionally


### PR DESCRIPTION
## What

Bumps the `fff.nvim` version pin in `lua/config/plugins.lua` from `"0.9.0"` to `"0.9.4"`.

## Where

`lua/config/plugins.lua:10` — `version = vim.version.range("0.9.0")` → `vim.version.range("0.9.4")`

## Why it matters

The plugin is intentionally pinned (comment: *"this package breaks frequently, specify version"*), so new releases require a manual bump. v0.9.4 is the latest release as of June 2026. Issue #152 originally tracked updating to v0.9.1; this PR advances directly to the current latest.

## After merging

Run `:SyncPkgs` to apply — `vim.pack` will resolve the new tag and update `nvim-pack-lock.json` automatically. The `PackChanged` autocmd in `plugin_config.lua` will trigger a binary rebuild if needed.

## Test plan
- [ ] Run `:SyncPkgs` and confirm fff.nvim installs at v0.9.4
- [ ] Verify `<leader>ff` (find files) and `<leader>fg` (live grep) still work
- [ ] Confirm the Rust binary rebuilds via the `PackChanged` autocmd

Advances #152.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfHniedWQBWikXmdJFVwur)_