### PR TITLE
[audit] fff.nvim: remove debug/score-display flags from production config

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -177,10 +177,6 @@ vim.api.nvim_create_autocmd("PackChanged", {
 })
 vim.g.fff = {
     lazy_sync = true,
-    debug = {
-        enabled = true,
-        show_scores = true,
-    },
 }
 if not is_vscode then
     local function fff_call(fn)


### PR DESCRIPTION
## What

Removes `debug.enabled = true` and `show_scores = true` from the `vim.g.fff` config table in `lua/config/plugin_config.lua`.

## Where

`lua/config/plugin_config.lua:178–184` (before this PR):

```lua
vim.g.fff = {
    lazy_sync = true,
    debug = {
        enabled = true,
        show_scores = true,
    },
}
```

After:

```lua
vim.g.fff = {
    lazy_sync = true,
}
```

## Why it matters

- `debug.enabled = true` enables verbose logging from the fff.nvim Rust binary, writing extra output that is not useful in normal use.
- `show_scores = true` annotates every search result with its fuzzy-match score, cluttering the picker UI during daily file/grep navigation.
- These appear to be development leftovers; there is no comment indicating they are intentional.

## Test plan
- [ ] Open `<leader>ff` — confirm no score annotations appear next to filenames
- [ ] Open `<leader>fg` — confirm grep results are clean
- [ ] Confirm no Rust panic or unexpected fff warnings in `:messages`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfHniedWQBWikXmdJFVwur)_