### PR TITLE
[audit] set showmode=false — redundant with custom statusline

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -56,7 +56,7 @@ vim.diagnostic.config({
 })
 
 -- misc settings
-vim.o.showmode = true
+vim.o.showmode = false -- custom statusline shows mode; built-in "-- INSERT --" is redundant
 vim.o.autoread = true
 vim.o.ignorecase = true
 vim.o.expandtab = true


### PR DESCRIPTION
## What

`lua/config/options.lua:59` sets `vim.o.showmode = true`.

## Where

`lua/config/options.lua` — line 59.

## Why it matters

The custom statusline (`lua/config/statusline.lua`) already renders a colour-coded mode indicator — `[N]` (green), `[I]` (purple), `[V]` (yellow), etc. — on every mode change. With `showmode = true`, Neovim *also* prints `-- INSERT --` / `-- VISUAL --` in the command-line area below the statusline, giving two simultaneous mode displays. Setting it to `false` removes the redundant message without losing any information.

## Recommended action

```diff
-vim.o.showmode = true
+vim.o.showmode = false -- custom statusline shows mode; built-in "-- INSERT --" is redundant
```

## Test plan
- [ ] Enter insert mode → only the statusline `[I]` indicator shows; no `-- INSERT --` in the cmdline
- [ ] Enter visual mode → only `[V]` in statusline
- [ ] Enter command mode → `[C]` in statusline; no `-- COMMAND --` below

https://claude.ai/code/session_01GHYEWxoG5uHqsZM28upN1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHYEWxoG5uHqsZM28upN1w)_