### PR TITLE
[audit] remove dead nvim&lt;0.12 branch from LspToggle

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -122,11 +122,7 @@ if not is_vscode then
     vim.api.nvim_create_user_command("LspToggle", function(opts)
         local name = opts.args
         for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
-            if vim.fn.has('nvim-0.12') == 1 then
-                client:stop()
-            else
-                vim.lsp.stop_client(client.id)
-            end
+            client:stop()
             return
         end
         vim.lsp.enable(name)


### PR DESCRIPTION
## What

`lua/config/plugin_config.lua` — the `LspToggle` user command — contains a version guard that was added for backward compatibility with Neovim < 0.12:

```lua
if vim.fn.has('nvim-0.12') == 1 then
    client:stop()
else
    vim.lsp.stop_client(client.id)  -- deprecated in 0.12
end
```

## Where

`lua/config/plugin_config.lua` — `LspToggle` command body, lines 125–130.

## Why it matters

The config already requires Neovim 0.12+ exclusively: `vim.lsp.config()`, `vim.lsp.enable()`, and `vim.pack` are all 0.12 APIs used unconditionally throughout the config. The `else` branch is therefore **dead code** — it can never execute — and it points at `vim.lsp.stop_client()`, which is deprecated in 0.12 and will be removed in a future version.

## Change

Remove the version guard; call `client:stop()` unconditionally:

```diff
-            if vim.fn.has('nvim-0.12') == 1 then
-                client:stop()
-            else
-                vim.lsp.stop_client(client.id)
-            end
+            client:stop()
```

## Test plan
- [ ] `:LspToggle luals` on a Lua buffer → luals stops
- [ ] Run again → luals re-enables
- [ ] No `vim.lsp.stop_client` deprecation warning in `:checkhealth`

https://claude.ai/code/session_01GHYEWxoG5uHqsZM28upN1w

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHYEWxoG5uHqsZM28upN1w)_