### PR TITLE
feat: add keymaps to yank file path to clipboard

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -31,6 +31,16 @@ vim.keymap.set("n", "<leader>f", ":find **/*")
 vim.cmd.cnoreabbrev("vimgrep", "vimgrep /pattern/gj **/*")
 vim.keymap.set("n", "<leader>co", "<cmd>copen<CR>", { desc = "[O]pen quickfix list" })
 vim.keymap.set("n", "<leader>cc", "<cmd>cclose<CR>", { desc = "[C]lose quickfix list" })
+vim.keymap.set("n", "<leader>yp", function()
+    local path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ":.")
+    vim.fn.setreg("+", path)
+    vim.notify("Copied: " .. path, vim.log.levels.INFO)
+end, { desc = "Yank file path (relative)" })
+vim.keymap.set("n", "<leader>yP", function()
+    local path = vim.api.nvim_buf_get_name(0)
+    vim.fn.setreg("+", path)
+    vim.notify("Copied: " .. path, vim.log.levels.INFO)
+end, { desc = "Yank file path (absolute)" })
 -- completion
 -- c-n for keyword completion
 -- c-e to cancel completion


### PR DESCRIPTION
Adds `<leader>yp` (relative path) and `<leader>yP` (absolute path) keymaps to `lua/config/options.lua`.

Closes #185.

Generated with [Claude Code](https://claude.ai/code)