### PR TITLE
[audit] Remove deprecated vim.lsp.stop_client() dead branch in LspToggle

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -122,11 +122,7 @@ if not is_vscode then
     vim.api.nvim_create_user_command("LspToggle", function(opts)
         local name = opts.args
         for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
-            if vim.fn.has('nvim-0.12') == 1 then
-                client:stop()
-            else
-                vim.lsp.stop_client(client.id)
-            end
+            client:stop()
             return
         end
         vim.lsp.enable(name)


### PR DESCRIPTION
## What

Remove the `vim.fn.has('nvim-0.12')` version branch inside `LspToggle` and call `client:stop()` unconditionally.

**File:** `lua/config/plugin_config.lua:124-130`

**Before:**
```lua
for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
    if vim.fn.has('nvim-0.12') == 1 then
        client:stop()
    else
        vim.lsp.stop_client(client.id)  -- deprecated in 0.12
    end
    return
end
```

**After:**
```lua
for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
    client:stop()
    return
end
```

## Why it matters

`vim.lsp.stop_client()` was deprecated in Neovim 0.12 in favour of `client:stop()` (confirmed in [Neovim 0.12 release notes](https://github.com/neovim/neovim/blob/v0.12.0/runtime/doc/news.txt)). The config already requires 0.12+ everywhere else (`vim.lsp.config`, `vim.lsp.enable`, `vim.pack`, `PackChanged` event), so the `else` branch is dead weight that will never execute.

## Risk

None — the removed branch was already unreachable on the effective minimum Neovim version.

https://claude.ai/code/session_01RZqsvzmVzHrEFysuE6VH6a

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZqsvzmVzHrEFysuE6VH6a)_