### PR TITLE
[audit] sneaks_ok undefined — sneak f/F/t/T remaps never applied

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -46,7 +46,8 @@ end
 
 -- sneaks — intentionally remaps s/S to 2-char forward/backward seek motion
 -- git clone --depth 1 https://github.com/justinmk/vim-sneak ~/.config/nvim/pack/plugins/start/vim-sneak
--- vim-sneak is a Vimscript plugin: plugin/sneak.vim sets g:loaded_sneak_plugin at startup. local sneaks_ok = vim.g.loaded_sneak_plugin ~= nil
+-- vim-sneak is a Vimscript plugin: plugin/sneak.vim sets g:loaded_sneak_plugin at startup.
+local sneaks_ok = vim.g.loaded_sneak_plugin ~= nil
 if sneaks_ok then
     vim.g["sneak#label"] = 1 -- label mode: shows jump targets (EasyMotion-style)
     vim.g["sneak#use_ic_scs"] = 1 -- respect smartcase (so type P will specifically match P)


### PR DESCRIPTION
## What

`sneaks_ok` was used as a guard variable but never defined — its definition was accidentally embedded in a comment, making it an undefined Lua global (evaluates to `nil`). The `if sneaks_ok then` block therefore never ran.

## Where

`lua/config/plugin_config.lua` line 49 (before this fix):

```lua
-- vim-sneak is a Vimscript plugin: plugin/sneak.vim sets g:loaded_sneak_plugin at startup. local sneaks_ok = vim.g.loaded_sneak_plugin ~= nil
if sneaks_ok then   -- ← always false: sneaks_ok is nil
    vim.g["sneak#label"] = 1
    vim.g["sneak#use_ic_scs"] = 1
    vim.keymap.set({"n","x","o"}, "f", "<Plug>Sneak_f")
    ...
```

## Why it matters

All sneak configuration was silently dead:
- Label mode (`sneak#label = 1`) never set → no jump-target overlays
- Smart-case (`sneak#use_ic_scs = 1`) never set
- `f`/`F`/`t`/`T` were **not** remapped to `<Plug>Sneak_*`, so the native Vim motions remained, making vim-sneak functionally unused despite being installed

## Fix

Split the combined comment+code line into a real comment and a real `local` assignment:

```lua
-- vim-sneak is a Vimscript plugin: plugin/sneak.vim sets g:loaded_sneak_plugin at startup.
local sneaks_ok = vim.g.loaded_sneak_plugin ~= nil
if sneaks_ok then
```

Low-risk: the change only un-comments an assignment that was always intended to be real code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxgkUEPPPRyo1ErnR5c86T)_