### PR TITLE
feat: add nvim-lint with ruff, luacheck, shellcheck

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -163,6 +163,22 @@ if conform_ok and not is_vscode then
     end, { desc = "Format buffer or selection" })
 end
 
+-- nvim-lint (async linting: ruff for Python, luacheck for Lua, shellcheck for Shell)
+local lint_ok, lint = pcall(require, "nvim-lint")
+if lint_ok and not is_vscode then
+    lint.linters_by_ft = {
+        python = { "ruff" },
+        lua = { "luacheck" },
+        sh = { "shellcheck" },
+        bash = { "shellcheck" },
+    }
+    vim.api.nvim_create_autocmd({ "BufWritePost", "InsertLeave" }, {
+        callback = function()
+            lint.try_lint()
+        end,
+    })
+end
+
 -- fff
 -- rebuild the rust binary whenever vim.pack installs/updates fff.nvim
 vim.api.nvim_create_autocmd("PackChanged", {

--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -20,6 +20,7 @@ local package_list = {
         src = "https://github.com/nvim-treesitter/nvim-treesitter-textobjects.git",
     },
     { name = "conform.nvim", src = "https://github.com/stevearc/conform.nvim.git" },
+    { name = "nvim-lint", src = "https://github.com/mfussenegger/nvim-lint.git" },
     { name = "gitsigns.nvim", src = "https://github.com/lewis6991/gitsigns.nvim.git" },
     { name = "obsidian.nvim", src = "https://github.com/obsidian-nvim/obsidian.nvim.git", skip_old_nvim = true },
     { name = "plenary.nvim", src = "https://github.com/nvim-lua/plenary.nvim.git" },


### PR DESCRIPTION
Adds async linting via nvim-lint alongside the existing conform.nvim formatter setup. Fires on BufWritePost and InsertLeave, populating vim.diagnostic with no new UI required.

Linters configured:
- Python → ruff
- Lua → luacheck
- Shell → shellcheck (sh and bash filetypes)

Closes #200

Generated with [Claude Code](https://claude.ai/code)