### PR TITLE
[audit] fix sneaks_ok undefined — vim-sneak keymaps silently disabled

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -46,7 +46,8 @@ end
 
 -- sneaks — intentionally remaps s/S to 2-char forward/backward seek motion
 -- git clone --depth 1 https://github.com/justinmk/vim-sneak ~/.config/nvim/pack/plugins/start/vim-sneak
--- vim-sneak is a Vimscript plugin: plugin/sneak.vim sets g:loaded_sneak_plugin at startup. local sneaks_ok = vim.g.loaded_sneak_plugin ~= nil
+-- vim-sneak is a Vimscript plugin: plugin/sneak.vim sets g:loaded_sneak_plugin at startup
+local sneaks_ok = vim.g.loaded_sneak_plugin ~= nil
 if sneaks_ok then
     vim.g["sneak#label"] = 1 -- label mode: shows jump targets (EasyMotion-style)
     vim.g["sneak#use_ic_scs"] = 1 -- respect smartcase (so type P will specifically match P)


### PR DESCRIPTION
## What

`lua/config/plugin_config.lua:49` — the variable declaration
`local sneaks_ok = vim.g.loaded_sneak_plugin ~= nil` was accidentally
appended to the end of a Lua comment (`-- vim-sneak is a Vimscript
plugin…`), so it was never executed.

`sneaks_ok` was therefore always `nil` (an undefined global), and
`if sneaks_ok then` on the next line was always false. **All vim-sneak
keymaps (`f`, `F`, `t`, `T`) were silently never registered**, even
when the plugin is installed and loaded correctly.

## Where

`lua/config/plugin_config.lua`, lines 49–50 (before this fix)

## Why it matters

vim-sneak's label-mode `f`/`F`/`t`/`T` overrides are the whole reason
the plugin is installed. Without this fix the user gets Vim's default
single-char `f`/`F`/`t`/`T` with no label highlighting — vim-sneak is
present but completely inert.

## Fix

Split the comment into a pure explanation comment and a separate
executable assignment on its own line. One-line change, no behaviour
change other than making the keymaps actually register.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYowDg8j3bC8avU2nv9KJm)_