### PR TITLE
Add conform auto-format-on-save toggle

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -157,11 +157,26 @@ if conform_ok and not is_vscode then
             typescriptreact = { "prettier" },
         },
     })
+    local auto_format = false
+
+    vim.api.nvim_create_autocmd("BufWritePre", {
+        callback = function(ev)
+            if auto_format then
+                conform.format({ bufnr = ev.buf })
+            end
+        end,
+    })
+
     -- conform derives the range from the live selection in visual mode;
     -- the '< '> marks are stale until visual mode is left, so don't use them here
     vim.keymap.set({ "n", "v" }, "<leader>lf", function()
         conform.format()
     end, { desc = "Format buffer or selection" })
+
+    vim.keymap.set("n", "<leader>lF", function()
+        auto_format = not auto_format
+        vim.notify("Auto-format: " .. (auto_format and "ON" or "OFF"), vim.log.levels.INFO)
+    end, { desc = "Toggle auto-format on save" })
 end
 
 -- nvim-lint (async linting: ruff for Python, luacheck for Lua, shellcheck for Shell)


### PR DESCRIPTION
### Motivation

- Provide an opt-in auto-format-on-save hook for the existing `conform.nvim` formatter so users can enable buffer formatting on write without changing the manual keymap behavior. 
- Mirror the existing keymap capitalization pattern by adding a session-scoped toggle for discoverability and consistency with other mappings. 
- Make the feature default-off to avoid surprising behavior on first launch.

### Description

- Add a `local auto_format = false` flag and a `BufWritePre` autocmd in `lua/config/plugin_config.lua` that calls `conform.format({ bufnr = ev.buf })` only when the flag is enabled. 
- Keep the existing manual format keymap `vim.keymap.set({ "n", "v" }, "<leader>lf", ...)` unchanged. 
- Add a new keymap `vim.keymap.set("n", "<leader>lF", ...)` to toggle `auto_format` and notify the user with `vim.notify` about the current state.

### Testing

- Ran `nvim --headless '+luafile lua/config/plugin_config.lua' '+qa'` to validate the config loading, but it failed because `nvim` is not installed in the environment. 
- Ran `luac -p lua/config/plugin_config.lua` to check Lua syntax, but it failed because `luac` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32c10a9d5883278ebace209f18c55c)