### PR TITLE
Add refactoring, tiny-inline-diagnostic and render-markdown plugins with basic configs

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -254,6 +254,22 @@ if gitsigns_ok and not is_vscode then
     gitsigns.setup()
 end
 
+-- tiny-inline-diagnostic (compact inline diagnostics)
+local tiny_diag_ok, tiny_diag = pcall(require, "tiny-inline-diagnostic")
+if tiny_diag_ok and not is_vscode then
+    tiny_diag.setup({
+        preset = "modern",
+        options = {
+            multilines = true,
+            show_source = {
+                enabled = true,
+                if_many = true,
+            },
+        },
+    })
+    vim.diagnostic.config({ virtual_text = false })
+end
+
 -- git change navigation (]g / [g)
 -- use native diff/hunk jump in diff view
 -- use gitsigns diff/hunk jump in regular view
@@ -272,6 +288,33 @@ if not is_vscode then
             gitsigns.nav_hunk("prev")
         end
     end, { desc = "Prev git change (hunk / diff)" })
+end
+
+-- refactoring.nvim (treesitter-driven extract/inline helpers)
+local refactoring_ok, refactoring = pcall(require, "refactoring")
+if refactoring_ok and not is_vscode then
+    refactoring.setup({})
+    vim.keymap.set("x", "<leader>re", function()
+        refactoring.refactor("Extract Function")
+    end, { desc = "Refactor extract function" })
+    vim.keymap.set("x", "<leader>rf", function()
+        refactoring.refactor("Extract Function To File")
+    end, { desc = "Refactor extract function to file" })
+    vim.keymap.set("x", "<leader>rv", function()
+        refactoring.refactor("Extract Variable")
+    end, { desc = "Refactor extract variable" })
+    vim.keymap.set({ "n", "x" }, "<leader>ri", function()
+        refactoring.refactor("Inline Variable")
+    end, { desc = "Refactor inline variable" })
+    vim.keymap.set("n", "<leader>rI", function()
+        refactoring.refactor("Inline Function")
+    end, { desc = "Refactor inline function" })
+    vim.keymap.set("n", "<leader>rb", function()
+        refactoring.refactor("Extract Block")
+    end, { desc = "Refactor extract block" })
+    vim.keymap.set("n", "<leader>rB", function()
+        refactoring.refactor("Extract Block To File")
+    end, { desc = "Refactor extract block to file" })
 end
 
 -- treesitter textobjects (move keymaps for function/class navigation)
@@ -307,6 +350,16 @@ if tso_ok and not is_vscode then
     vim.keymap.set({ "n", "x", "o" }, "[C", function()
         move.goto_previous_end("@class.outer", "textobjects")
     end, { desc = "Prev class end" })
+end
+
+-- render-markdown (in-buffer markdown rendering)
+local render_markdown_ok, render_markdown = pcall(require, "render-markdown")
+if render_markdown_ok and not is_vscode then
+    render_markdown.setup({
+        file_types = { "markdown" },
+        completions = { lsp = { enabled = true } },
+    })
+    vim.keymap.set("n", "<leader>mr", "<cmd>RenderMarkdown toggle<CR>", { desc = "Toggle markdown rendering" })
 end
 
 -- obsidian

--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -21,10 +21,14 @@ local package_list = {
         name = "nvim-treesitter-textobjects",
         src = "https://github.com/nvim-treesitter/nvim-treesitter-textobjects.git",
     },
+    { name = "async.nvim", src = "https://github.com/lewis6991/async.nvim.git" },
+    { name = "refactoring.nvim", src = "https://github.com/ThePrimeagen/refactoring.nvim.git" },
     { name = "conform.nvim", src = "https://github.com/stevearc/conform.nvim.git" },
     { name = "nvim-lint", src = "https://github.com/mfussenegger/nvim-lint.git" },
     { name = "gitsigns.nvim", src = "https://github.com/lewis6991/gitsigns.nvim.git" },
+    { name = "tiny-inline-diagnostic.nvim", src = "https://github.com/rachartier/tiny-inline-diagnostic.nvim.git" },
     { name = "obsidian.nvim", src = "https://github.com/obsidian-nvim/obsidian.nvim.git", skip_old_nvim = true },
+    { name = "render-markdown.nvim", src = "https://github.com/MeanderingProgrammer/render-markdown.nvim.git" },
     { name = "plenary.nvim", src = "https://github.com/nvim-lua/plenary.nvim.git" },
     { name = "dark-theme", src = "https://github.com/stanfish06/dark-theme.git" },
     { name = "rose-pine", src = "https://github.com/rose-pine/neovim.git" },
@@ -34,7 +38,7 @@ local package_list = {
     { name = "tinted-vim", src = "https://github.com/tinted-theming/tinted-vim.git" },
     { name = "snacks.nvim", src = "https://github.com/folke/snacks.nvim.git" },
     { name = "noice.nvim", src = "https://github.com/folke/noice.nvim.git" },
-    { name = "quicker.nvim", src = "https://github.com/stevearc/quicker.nvim.git"},
+    { name = "quicker.nvim", src = "https://github.com/stevearc/quicker.nvim.git" },
     { name = "nui.nvim", src = "https://github.com/MunifTanjim/nui.nvim.git" },
 }
 local vim_pack_ok, _ = pcall(require, "vim.pack")


### PR DESCRIPTION
### Motivation
- The PR implements the requested complementary plugins to add structured refactoring, compact inline diagnostics, and in-buffer markdown rendering while leaving out `octo.nvim` and `git-conflict.nvim` as requested.
- Changes follow the repo's existing plugin registration and config style so the features integrate with the current LSP/treesitter/quickfix workflows.

### Description
- Added package entries to `lua/config/plugins.lua` for `async.nvim`, `refactoring.nvim`, `tiny-inline-diagnostic.nvim`, and `render-markdown.nvim`.
- Added a `tiny-inline-diagnostic` setup in `lua/config/plugin_config.lua` that uses the `modern` preset, enables multiline/source display, and disables native diagnostic `virtual_text` when the plugin loads.
- Added a `refactoring.nvim` setup and basic treesitter-driven refactor keymaps under the `<leader>r` prefix (extract/inline function/variable/block and variants).
- Added a `render-markdown.nvim` setup for markdown buffers with LSP completions enabled and a toggle keymap at `<leader>mr`.

### Testing
- Ran `git diff --check` and it reported no whitespace or diff-check issues (success).
- Attempted `nvim --headless -u init.lua '+lua print("config ok")' +qa` to validate runtime loading, but it failed because `nvim` is not installed in the environment (could not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ad0bcd0d4832794c9ca5c1896a9d5)