### PR TITLE
[audit] guard nvim-web-devicons require with pcall in statuscolumn

### DIFF
--- a/lua/config/statuscolumn.lua
+++ b/lua/config/statuscolumn.lua
@@ -18,12 +18,18 @@ function Directory()
         icon_color = "Directory"
     else
         -- use your favorite icon provider.
-        local extension = vim.fs.ext(name)
-        local devicons = require("nvim-web-devicons")
-        icon, icon_color = devicons.get_icon(name, extension)
-        if not icon then
-            icon, icon_color = devicons.get_icon_by_filetype(vim.bo[0].filetype, { default = true })
+        local devicons_ok, devicons = pcall(require, "nvim-web-devicons")
+        if devicons_ok then
+            local extension = vim.fs.ext(name)
+            icon, icon_color = devicons.get_icon(name, extension)
+            if not icon then
+                icon, icon_color = devicons.get_icon_by_filetype(vim.bo[0].filetype, { default = true })
+            end
         end
+    end
+
+    if not icon then
+        return double_space
     end
 
     return table.concat({


### PR DESCRIPTION
## What
`Directory()` in `lua/config/statuscolumn.lua:22` called `require("nvim-web-devicons")` directly, with no `pcall` guard.

## Where
`lua/config/statuscolumn.lua:20-26` (the `else` branch of `Directory()`, used for the `directory`/`netrw` filetype statuscolumn).

## Why
Every other optional-plugin dependency in this config (fzf-lua, blink.cmp, gitsigns, fff.nvim, diffview, etc. in `lua/config/plugin_config.lua`) is loaded via `local ok, mod = pcall(require, "modname")`. This file breaks that convention: if `nvim-web-devicons` isn't installed/loaded yet, `Directory()` throws on every redraw of a `directory`/`netrw` buffer's statuscolumn (since `statuscolumn` is re-evaluated very frequently).

## Recommended action (applied)
- Wrap the require in `pcall`, and only attempt `vim.fs.ext()` / `get_icon()` / `get_icon_by_filetype()` when the module loaded successfully.
- Added a `if not icon then return double_space end` fallback before building the final virtual text, mirroring the existing `virtnum ~= 0` early return.
- The `""` nerd font folder icon literal and all other glyphs are left byte-for-byte unchanged.

No behavior change in the happy path (devicons installed); only adds a safe fallback when it isn't.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KssBkvbBnXmz2Jpf5jspoL)_