### PR TITLE
[audit] add gofmt to conform.nvim formatters_by_ft

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -166,6 +166,7 @@ if conform_ok and not is_vscode then
             javascriptreact = { "prettier" },
             typescript = { "prettier" },
             typescriptreact = { "prettier" },
+            go = { "gofmt" },
         },
     })
     local auto_format = false


### PR DESCRIPTION
## What
`gopls` is enabled (`lua/config/plugin_config.lua`) but conform.nvim's `formatters_by_ft` had no `go` entry, so `lf` on a Go buffer fell through to `lsp_format = "fallback"` (gopls's own formatter) and skipped conform entirely — including the visual-range format path (`v lf`).

## Where
`lua/config/plugin_config.lua` — `conform.setup({ formatters_by_ft = {...} })`, right next to the other per-language entries.

## Why it matters
Closes #168. Every other enabled LSP in this config has a matching explicit formatter entry; Go was the one gap. `gofmt` is stdlib (no extra binary to install), so this doesn't add a new dependency.

## Recommended action (applied)
Added `go = { "gofmt" }` to `formatters_by_ft`. Picked `gofmt` over `goimports` to avoid requiring an extra install; happy to switch to `goimports` if import organization is wanted (the issue's own alternative).

Closes #168.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QBrmXdBVDhDNZULcGsoYY9)_