### PR TITLE
[audit] Remove verbose UI-layer startup notifications

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -428,12 +428,7 @@ if not vim.g.vscode then
         if ui2_ok then
             -- {} required: calling enable() without args is a documented Neovim bug (neovim/neovim#38594)
             pcall(ui2.enable, {})
-            vim.notify("nvim ui2 enabled", vim.log.levels.INFO)
-        else
-            vim.notify("nvim ui2 disabled (could be old nvim or api shift, check options.lua)", vim.log.levels.WARN)
         end
-    else
-        vim.notify("use noice/nui ui layer", vim.log.levels.INFO)
     end
 end
 if noice_ok and not is_vscode then


### PR DESCRIPTION
## What

Three `vim.notify()` calls in `lua/config/plugin_config.lua` fired on every Neovim startup:

- `"nvim ui2 enabled"` (INFO) — when noice is absent and ui2 loads successfully
- `"nvim ui2 disabled (could be old nvim or api shift, check options.lua)"` (WARN) — when neither noice nor ui2 is available
- `"use noice/nui ui layer"` (INFO) — on every normal startup when noice is installed

## Where

`lua/config/plugin_config.lua:428–437` (the noice/ui2 detection block)

## Why it matters

These are debug breadcrumbs left over from development. In normal usage:
- The noice INFO fires on **every single startup** via the snacks notifier pop-up
- The ui2 notifications are also always shown when noice is unavailable
- None carry actionable information once the setup is stable

## Change

Removed the three `vim.notify()` calls. The `ui2.enable({})` call is kept intact — only the notifications are dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDAiArveSebnvDdd2C2qfB)_