### PR TITLE
[audit] scope char_at as local — fix global namespace pollution in scopeline.lua

### DIFF
--- a/lua/config/scopeline.lua
+++ b/lua/config/scopeline.lua
@@ -30,7 +30,7 @@ local valid_scopes = {
     ["type_declaration"] = true,
 }
 local ns_scope_line = vim.api.nvim_create_namespace("scope_line")
-function char_at(row, col)
+local function char_at(row, col)
     -- row is 1-based, col is 1-based
     local line = vim.api.nvim_buf_get_lines(0, row - 1, row, false)[1] or ""
     return string.sub(line, col, col)
@@ -46,12 +46,12 @@ local function draw_scope_lines()
             for i = start_row + 1, end_row do
                 local char = char_at(i + 1, start_col + 1) -- treesitter is 0 based
                 if char == " " or char == "" then
-                    local scope_char = "│"
+                    local scope_char = "\u{2502}"
                     if i == start_row + 1 and (end_row - start_row) > 1 then
-                        scope_char = "┌"
+                        scope_char = "\u{250C}"
                     end
                     if i == end_row and (end_row - start_row) > 1 then
-                        scope_char = "└"
+                        scope_char = "\u{2514}"
                     end
                     pcall(
                         vim.api.nvim_buf_set_extmark,

--- a/lua/config/scopeline.lua
+++ b/lua/config/scopeline.lua
@@ -46,12 +46,12 @@ local function draw_scope_lines()
             for i = start_row + 1, end_row do
                 local char = char_at(i + 1, start_col + 1) -- treesitter is 0 based
                 if char == " " or char == "" then
-                    local scope_char = "\u{2502}"
+                    local scope_char = "│"
                     if i == start_row + 1 and (end_row - start_row) > 1 then
-                        scope_char = "\u{250C}"
+                        scope_char = "┌"
                     end
                     if i == end_row and (end_row - start_row) > 1 then
-                        scope_char = "\u{2514}"
+                        scope_char = "└"
                     end
                     pcall(
                         vim.api.nvim_buf_set_extmark,


### PR DESCRIPTION
## What

`char_at()` in `lua/config/scopeline.lua:33` was declared without `local`, making it a module-level global that leaks into `_G`. Any other module that accidentally references `char_at` would silently pick up this function instead of erroring.

## Where

`lua/config/scopeline.lua:33`

```lua
-- before
function char_at(row, col)

-- after
local function char_at(row, col)
```

## Why it matters

Lua globals are shared across the entire process. An accidentally-global utility function is an invisible name-collision hazard: if any plugin or future config file defines or calls `char_at` expecting something else, it silently gets this implementation. Scoping it `local` matches the intention (it's only called by `draw_scope_lines` in the same file) and follows the pattern already used for every other function in this file.

## Risk

Zero functional change — `char_at` is only called from `draw_scope_lines` in the same file, and `local` is visible to everything in the same scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjZpUsA6ogTd8u1eEoxwTf)_