### PR TITLE
[audit] Fix DescribeKey clobbering @a register

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -147,7 +147,9 @@ end, { expr = true, noremap = true })
 -- check full keymap and dump to a new buffer
 -- TUDO: it is worth to extend it with fuzzy finding and better UI
 local function which_key()
-    vim.cmd("redir @a | silent map | redir END | new | put a")
+    local output = vim.fn.execute("map")
+    vim.cmd("new")
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, vim.split(output, "\n"))
 end
 vim.api.nvim_create_user_command("DescribeKey", which_key, {})
 


### PR DESCRIPTION
## What

`DescribeKey` (options.lua:149–151) dumps the output of `:map` into register `@a` via `redir`, then yanks it into a new buffer. Any text previously in `@a` (e.g. a word yanked with `yiw`) is silently destroyed.

## Where

`lua/config/options.lua:150`

```lua
-- before
vim.cmd("redir @a | silent map | redir END | new | put a")

-- after
local output = vim.fn.execute("map")
vim.cmd("new")
vim.api.nvim_buf_set_lines(0, 0, -1, false, vim.split(output, "\n"))
```

## Why it matters

`vim.fn.execute()` captures command output as a Lua string without touching any register. The resulting buffer is populated via `nvim_buf_set_lines`, which is equivalent to the old `put a` but register-safe. No behavioral change to the user-visible result.

## Recommended action

Already applied in this PR. No other changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAkUW53kMHdfTNifKknKuZ)_