### PR TITLE
[audit] Gate pyrefly vs pyright — prevent dual Python LSP attach

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -99,10 +99,13 @@ if not is_vscode then
             },
         },
     })
-    vim.lsp.enable("pyright")
     -- install via uv: uv tool install pyrefly, then pyrefly init inside project folder (will transfer configs from pyright if available)
-    -- pyrefly seems capable of showing more type issues as far as I can tell
-    vim.lsp.enable("pyrefly")
+    -- pyrefly seems capable of showing more type issues; prefer it when installed, fall back to pyright
+    if vim.fn.executable("pyrefly") == 1 then
+        vim.lsp.enable("pyrefly")
+    else
+        vim.lsp.enable("pyright")
+    end
     -- install using system package manager
     vim.lsp.enable("clangd")
     -- npm instal -g typescript-language-server


### PR DESCRIPTION
## What

`vim.lsp.enable("pyright")` and `vim.lsp.enable("pyrefly")` were both called unconditionally. On any machine where both tools are installed, two Python LSP clients attach to every `.py` file simultaneously.

**File:** `lua/config/plugin_config.lua:102-105`

## Why it matters

When two LSPs attach to the same filetype:
- Diagnostics are duplicated (same error shown twice, once per client)
- Hover/completion results are interleaved
- Code actions from both servers are merged, creating confusing duplicates

The inline comment already acknowledges pyrefly and pyright are alternatives ("pyrefly *seems* capable of showing more type issues"), not an intentional dual-server setup.

## Change

Prefer pyrefly when installed, fall back to pyright — only one attaches per session:

```lua
if vim.fn.executable("pyrefly") == 1 then
    vim.lsp.enable("pyrefly")
else
    vim.lsp.enable("pyright")
end
```

To switch back to pyright temporarily, either uninstall pyrefly or comment out its branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBEgozMQ7iHP5JETZTGfNi)_