### PR TITLE
[audit] fix LspToggle compat guard: nvim-0.12 → nvim-0.11

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -133,7 +133,7 @@ if not is_vscode then
     vim.api.nvim_create_user_command("LspToggle", function(opts)
         local name = opts.args
         for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
-            if vim.fn.has("nvim-0.12") == 1 then
+            if vim.fn.has("nvim-0.11") == 1 then
                 client:stop()
             else
                 vim.lsp.stop_client(client.id)


### PR DESCRIPTION
## What

`client:stop()` (colon-notation) has been available since Neovim **0.11**, as part of the broad client-method capitalisation sweep in that release. The version gate in `LspToggle` was checking for `nvim-0.12`, which meant `vim.lsp.stop_client()` (deprecated in 0.12) was called unnecessarily on any 0.11.x build.

## Where

`lua/config/plugin_config.lua` line 136

```lua
-- before
if vim.fn.has("nvim-0.12") == 1 then
-- after
if vim.fn.has("nvim-0.11") == 1 then
```

## Why it matters

- On Neovim 0.11, `vim.lsp.stop_client()` still works but is the legacy path; `client:stop()` is the correct modern call.
- On Neovim 0.12+, `vim.lsp.stop_client()` is **deprecated** (confirmed in `deprecated.txt` for v0.12.0).
- The one-release-late gate made the deprecated branch reachable on the newest stable Neovim.

## References

Closes #263

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKfbNcYh6hTyM3DVcni1Ch)_