### PR TITLE
Add mini.icons and mini.pairs

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -1,4 +1,20 @@
 local is_vscode = vim.g.vscode
+
+-- mini.icons (icon provider; mocks nvim-web-devicons so filetree.lua/statuscolumn.lua
+-- keep working against the devicons API without changes)
+local mini_icons_ok, mini_icons = pcall(require, "mini.icons")
+if mini_icons_ok then
+    mini_icons.setup()
+    mini_icons.mock_nvim_web_devicons()
+end
+
+-- mini.pairs (auto-close brackets/quotes; complements the <CR> auto-indent
+-- keymap in options.lua which handles the reactive side of bracket editing)
+local mini_pairs_ok, mini_pairs = pcall(require, "mini.pairs")
+if mini_pairs_ok and not is_vscode then
+    mini_pairs.setup()
+end
+
 -- fzf
 -- git clone --depth 1 https://github.com/ibhagwan/fzf-lua.git ~/.config/nvim/pack/plugins/start/fzf-lua
 local ok, fzf = pcall(require, "fzf-lua")

--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -40,7 +40,7 @@ local package_list = {
     { name = "noice.nvim", src = "https://github.com/folke/noice.nvim.git" },
     { name = "quicker.nvim", src = "https://github.com/stevearc/quicker.nvim.git" },
     { name = "nui.nvim", src = "https://github.com/MunifTanjim/nui.nvim.git" },
-    { name = "nvim-web-devicons", src = "https://github.com/nvim-tree/nvim-web-devicons.git" }
+    { name = "mini.nvim", src = "https://github.com/echasnovski/mini.nvim.git" }
 }
 local vim_pack_ok, _ = pcall(require, "vim.pack")
 local function sync_packages()

--- a/nvim-pack-lock.json
+++ b/nvim-pack-lock.json
@@ -38,7 +38,7 @@
       "src": "https://tpope.io/vim/fugitive.git"
     },
     "fzf-lua": {
-      "rev": "774150bc05f774af1df614f55d156b3318c6decd",
+      "rev": "ed4059deb9237f7f4cc8832ffef69779ffe2e265",
       "src": "https://github.com/ibhagwan/fzf-lua.git"
     },
     "gitsigns.nvim": {
@@ -48,6 +48,10 @@
     "guh.nvim": {
       "rev": "943779f7cdb0acee203985ad531fb53ff95d9c8e",
       "src": "https://github.com/justinmk/guh.nvim"
+    },
+    "mini.nvim": {
+      "rev": "928971c3cfe99ddf29659acc31214cfa836fabe4",
+      "src": "https://github.com/echasnovski/mini.nvim.git"
     },
     "noice.nvim": {
       "rev": "7bfd942445fb63089b59f97ca487d605e715f155",
@@ -78,7 +82,7 @@
       "src": "https://github.com/nvim-tree/nvim-web-devicons.git"
     },
     "obsidian.nvim": {
-      "rev": "1052c0c8359c550d5379296f896a778284dc5a78",
+      "rev": "7687c7e62c3e12617d9eea6401e9e1f190e2ccab",
       "src": "https://github.com/obsidian-nvim/obsidian.nvim.git"
     },
     "plenary.nvim": {


### PR DESCRIPTION
## Summary
- Replace `nvim-web-devicons` with `mini.icons` in `lua/config/plugins.lua`, using `mock_nvim_web_devicons()` so existing call sites in `filetree.lua` and `statuscolumn.lua` need no changes.
- Add `mini.pairs` with default setup for automatic bracket/quote closing, complementing the existing `<CR>` auto-indent keymap in `options.lua`.

Closes #277

Generated with [Claude Code](https://claude.ai/code)