### PR TITLE
[audit] Guard native LSP completion when blink.cmp active; drop dead <0.11 compat

### DIFF
--- a/lua/config/plugin_config.lua
+++ b/lua/config/plugin_config.lua
@@ -137,7 +137,7 @@ if not is_vscode then
     vim.api.nvim_create_autocmd("LspAttach", {
         callback = function(ev)
             local client = vim.lsp.get_client_by_id(ev.data.client_id)
-            if client and client:supports_method("textDocument/completion") then
+            if not blink_ok and client and client:supports_method("textDocument/completion") then
                 pcall(function()
                     vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
                 end)
@@ -149,11 +149,7 @@ if not is_vscode then
     vim.api.nvim_create_user_command("LspToggle", function(opts)
         local name = opts.args
         for _, client in ipairs(vim.lsp.get_clients({ bufnr = 0, name = name })) do
-            if vim.fn.has("nvim-0.11") == 1 then
-                client:stop()
-            else
-                vim.lsp.stop_client(client.id)
-            end
+            client:stop()
             return
         end
         vim.lsp.enable(name)


### PR DESCRIPTION
## What

Two mechanical fixes in `lua/config/plugin_config.lua`.

### 1. `vim.lsp.completion.enable` conflicts with blink.cmp (line 140)

**Before:**
```lua
if client and client:supports_method("textDocument/completion") then
    pcall(function()
        vim.lsp.completion.enable(true, client.id, ev.buf, { autotrigger = true })
    end)
end
```

**After:**
```lua
if not blink_ok and client and client:supports_method("textDocument/completion") then
    ...
end
```

**Why:** When blink.cmp is installed and set up, it takes over the completion pipeline and registers its own `InsertCharPre`/`CompleteDone` autocmds. Calling `vim.lsp.completion.enable(autotrigger=true)` on top of that registers a *second* set of competing autocmds, causing both systems to fire on every keystroke. The `pcall` wrapper only prevents crashes — it does not prevent the runtime conflict. The guard makes native completion a fallback for when blink is absent.

### 2. Dead Neovim <0.11 branch in `LspToggle` (line 152)

**Before:**
```lua
if vim.fn.has("nvim-0.11") == 1 then
    client:stop()
else
    vim.lsp.stop_client(client.id)
end
```

**After:**
```lua
client:stop()
```

**Why:** The entire LSP configuration already uses `vim.lsp.config` / `vim.lsp.enable` (0.11+ only APIs), so the `else` branch (`vim.lsp.stop_client`) can never be reached on any Neovim version that can load this config.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCwH9LMeaXgjW5yZqEx4cv)_