### PR TITLE
[audit] Remove orphaned nvim-web-devicons entry from lock file

### DIFF
--- a/nvim-pack-lock.json
+++ b/nvim-pack-lock.json
@@ -77,10 +77,6 @@
       "rev": "851e865342e5a4cb1ae23d31caf6e991e1c99f1e",
       "src": "https://github.com/nvim-treesitter/nvim-treesitter-textobjects.git"
     },
-    "nvim-web-devicons": {
-      "rev": "dad71387de386a946b123079d0e53f23028f3abd",
-      "src": "https://github.com/nvim-tree/nvim-web-devicons.git"
-    },
     "obsidian.nvim": {
       "rev": "7687c7e62c3e12617d9eea6401e9e1f190e2ccab",
       "src": "https://github.com/obsidian-nvim/obsidian.nvim.git"


### PR DESCRIPTION
## What

Remove the stale `nvim-web-devicons` entry from `nvim-pack-lock.json`.

**File:** `nvim-pack-lock.json` (lines 80–83 before this change)

## Why it matters

`nvim-web-devicons` was removed from `package_list` in `lua/config/plugins.lua` when `mini.nvim` was added and `mini_icons.mock_nvim_web_devicons()` was set up to replace the module. However, the lock file entry was not cleaned up.

Two consequences:
1. The lock file entry is dead weight — `vim.pack` tracks a revision for a package it does not manage, which is confusing and could interfere with future lock file tooling.
2. If the `pack/plugins/start/nvim-web-devicons/` directory still exists on disk (which it likely does, since `:SyncPkgs` only removes packages *in* the list from the old dir), its `plugin/` init scripts still run at Neovim startup alongside mini.icons. `mini_icons.mock_nvim_web_devicons()` replaces `package.loaded["nvim-web-devicons"]` so `require()` calls return the mock, but the real plugin's highlight-group setup still executes redundantly.

## Recommended action

After merging, also delete the directory from your machine:

```sh
rm -rf ~/.config/nvim/pack/plugins/start/nvim-web-devicons
```

Then run `:SyncPkgs` (or `:PackerSync` if using the old path) to confirm the pack dir is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euu4acruJoQ3jbba9oTqqj)_