### PR TITLE
[audit] Prune orphaned vim.pack plugins so removed entries stay removed

### DIFF
--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -74,6 +74,17 @@ local function sync_packages()
         print("Install all packages...")
         vim.pack.add(package_list)
         print("All packages installed!")
+        -- packages removed from package_list are left on disk by vim.pack (never
+        -- deleted automatically) and stay "inactive"; update() below would otherwise
+        -- keep re-adding their stale lock file entry on every sync, see nvim-web-devicons
+        local inactive = vim.iter(vim.pack.get())
+            :filter(function(pkg) return not pkg.active end)
+            :map(function(pkg) return pkg.spec.name end)
+            :totable()
+        if #inactive > 0 then
+            print("Prune orphaned: " .. table.concat(inactive, ", "))
+            vim.pack.del(inactive)
+        end
         -- update() normally opens a confirmation buffer (:write applies it); in headless
         -- mode (README setup command) that buffer would just be discarded, so apply directly
         vim.pack.update(nil, { force = #vim.api.nvim_list_uis() == 0 })

--- a/nvim-pack-lock.json
+++ b/nvim-pack-lock.json
@@ -77,10 +77,6 @@
       "rev": "851e865342e5a4cb1ae23d31caf6e991e1c99f1e",
       "src": "https://github.com/nvim-treesitter/nvim-treesitter-textobjects.git"
     },
-    "nvim-web-devicons": {
-      "rev": "09d1324e264c6950262dbe02a9bce2933a6800db",
-      "src": "https://github.com/nvim-tree/nvim-web-devicons.git"
-    },
     "obsidian.nvim": {
       "rev": "bf1616d46e72477ad978051363fdb5c839c1cce5",
       "src": "https://github.com/obsidian-nvim/obsidian.nvim.git"


### PR DESCRIPTION
## What

`nvim-web-devicons` was removed from `nvim-pack-lock.json` by #285 (merged), because `mini.icons` now mocks it and it's no longer in `package_list`. It reappeared in the lock file a few commits later (`3a4f957`→`bbb40aa`) and is back as of today.

## Where

`lua/config/plugins.lua:74-79` (the `vim.pack` branch of `sync_packages()`)

## Why it matters

`vim.pack.add(package_list)` only registers the plugins currently in `package_list`. It never deletes a plugin that drops out of the list — the on-disk clone (under the gitignored `pack/` dir) just becomes "inactive". `vim.pack.get()` still reports it, and the subsequent `vim.pack.update(nil, {...})` call re-syncs the lock file against everything `vim.pack` knows about, so the stale entry gets written straight back in. #285's fix could only ever last until the next sync — it edited the symptom (the lock file) rather than the cause (vim.pack never being told to drop the package).

This isn't specific to `nvim-web-devicons`: any plugin removed from `package_list` in the future will silently keep reappearing in the lock file the same way, since nothing ever calls `vim.pack.del()`.

## Fix

After `vim.pack.add(package_list)`, find packages `vim.pack.get()` reports as `not active` (i.e. no longer in `package_list`) and `vim.pack.del()` them before `vim.pack.update()` runs:

```lua
local inactive = vim.iter(vim.pack.get())
    :filter(function(pkg) return not pkg.active end)
    :map(function(pkg) return pkg.spec.name end)
    :totable()
if #inactive > 0 then
    print("Prune orphaned: " .. table.concat(inactive, ", "))
    vim.pack.del(inactive)
end
```

Also removes the now-genuinely-stale `nvim-web-devicons` entry from `nvim-pack-lock.json` one more time — this time it should stick since the pruning step runs before the next auto-sync.

Mechanical, low-risk change scoped to the `vim.pack` sync path only; the legacy git-clone fallback path is untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QSVvNeoQ41JbrFXYUvStTD)_