### PR TITLE
[audit] Stop leaked tabline_timer handle on re-source

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -223,7 +223,16 @@ vim.o.tabline = '%!v:lua.TabLineCustom()'
 
 -- the tabline only redraws on events, so poll while any terminal exists to
 -- pick up foreground process changes
+--
+-- :source % re-runs this whole chunk with fresh locals, so a plain `local
+-- tabline_timer` would orphan the previous handle (its callback closure keeps
+-- it alive forever). Stash it on _G so a re-source can find and stop it.
+if _G.__tabline_timer and not _G.__tabline_timer:is_closing() then
+    _G.__tabline_timer:stop()
+    _G.__tabline_timer:close()
+end
 local tabline_timer = vim.uv.new_timer()
+_G.__tabline_timer = tabline_timer
 tabline_timer:start(2000, 2000, vim.schedule_wrap(function()
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
         if vim.bo[buf].buftype == 'terminal' then


### PR DESCRIPTION
## What

`lua/config/options.lua:226` creates a `vim.uv.new_timer()` as a plain `local` and starts it polling every 2s to redraw the tabline while a terminal buffer exists. Nothing ever stops it.

## Where

`lua/config/options.lua` (tabline foreground-process poller, ~line 224-234).

## Why it matters

`require("config.options")` only runs once per session so this is harmless on a normal launch. But `:source %` (or any re-source of this file, e.g. while iterating on config) re-runs the whole chunk with a fresh `local tabline_timer`. The *previous* timer handle is unreachable from Lua once its local goes out of scope, but libuv keeps it alive because the `vim.schedule_wrap` callback closure still references it — so it keeps firing forever. Each re-source leaks one more 2s-interval timer, each doing a `redrawtabline()` sweep over every buffer.

## Recommended action (implemented in this PR)

Stash the timer handle on `_G` and, before creating a new one, stop/close any handle left over from a prior source of this file:

```lua
if _G.__tabline_timer and not _G.__tabline_timer:is_closing() then
    _G.__tabline_timer:stop()
    _G.__tabline_timer:close()
end
local tabline_timer = vim.uv.new_timer()
_G.__tabline_timer = tabline_timer
tabline_timer:start(2000, 2000, ...)
```

This is a minimal, backward-compatible fix — behavior on a normal single launch is unchanged; it only prevents accumulation across re-sources.

Related to open issue #265.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfsVTaAzqLyCSmfq9kHX82)_