### PR TITLE
[audit] Wire checktime so autoread actually reloads changed buffers

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -68,6 +68,13 @@ vim.diagnostic.config({
 -- misc settings
 vim.o.showmode = true
 vim.o.autoread = true
+-- autoread alone only reloads a changed-on-disk buffer on a handful of
+-- vim-internal triggers (:e, some shell-outs); it does not poll, so external
+-- changes (git checkout, another instance saving) are silently missed until
+-- one of those triggers happens to fire. checktime forces the check.
+vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter", "CursorHold", "CursorHoldI" }, {
+    command = "checktime",
+})
 vim.o.ignorecase = true
 vim.o.expandtab = true
 vim.o.smartcase = true


### PR DESCRIPTION
## What

`lua/config/options.lua:70` sets `vim.o.autoread = true` with no accompanying `checktime` trigger.

## Where

`lua/config/options.lua` (misc settings block, ~line 68-70).

## Why it matters

`autoread` only reloads a buffer that changed on disk when Vim happens to run one of a small set of internal checks (`:e`, some shell-outs, etc.) — it does not poll on its own. In everyday use (switching branches, another process/instance writing the file, editing the same file from two terminals) the buffer silently stays stale until something incidentally triggers a check. This is a very common nvim config gap; the fix is the standard `checktime` autocmd.

## Recommended action (implemented in this PR)

```lua
vim.api.nvim_create_autocmd({ "FocusGained", "BufEnter", "CursorHold", "CursorHoldI" }, {
    command = "checktime",
})
```

Placed right after `vim.o.autoread = true` for locality. This only affects buffers backed by a real file; it's inert otherwise and doesn't change any existing keymap or command.

Related to open issue #262.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfsVTaAzqLyCSmfq9kHX82)_