### PR TITLE
[audit] Fix vim.ui.img.set() row/col to 1-indexed per documented API

### DIFF
--- a/lua/config/image.lua
+++ b/lua/config/image.lua
@@ -5,7 +5,7 @@ local function preview_image(path)
     -- mod_ui.Window.create_tmp_float_window()
     local id = vim.ui.img.set(
      vim.fn.readblob(path),
-     { row = 0, col = 0, width = 100, height = 50, zindex = 0 }
+     { row = 1, col = 1, width = 100, height = 50, zindex = 0 }
     )
     return id
 end


### PR DESCRIPTION
## What
`vim.ui.img.Opts.row`/`col` are documented as 1-indexed (`---@field row? integer starting row (1-indexed)`), and the built-in kitty backend builds the cursor-position escape as `\027[%d;%dH` directly from `opts.row or 1` / `opts.col or 1`.

## Where
`lua/config/image.lua:8` — `preview_image()` called `vim.ui.img.set(..., { row = 0, col = 0, ... })`.

## Why it matters
`0` is truthy in Lua, so it isn't caught by the `or 1` default and gets forwarded literally, producing the escape sequence for row/col position `0` — outside the documented 1-indexed contract. Most terminals happen to clamp `0` to `1`, which is why this hasn't visibly misbehaved, but it's relying on undefined/non-portable terminal clamping rather than the documented API. `vim.ui.img` is still an experimental, actively-changing API (gated behind `min = "0.13"` in `init.lua`), so keeping call sites strictly conformant matters more than usual here.

Related but distinct from #286 (which tracks migrating this whole module to `snacks.image` since `vim.ui.img` is otherwise broken) — this is a narrow correctness fix to the existing call site regardless of that broader migration decision.

## Recommended action (applied)
Changed `row = 0, col = 0` to `row = 1, col = 1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJzu414NEM2wcAQMtMZYhY)_